### PR TITLE
Cereberus Build Check

### DIFF
--- a/.github/workflows/build-cerberus.yml
+++ b/.github/workflows/build-cerberus.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Clone Embedded-base
         uses: actions/checkout@v3
         with:
+          repository: Northeastern-Electric-Racing/Embedded-Base
           path: "./Drivers"
 
       - name: Execute Make

--- a/.github/workflows/build-cerberus.yml
+++ b/.github/workflows/build-cerberus.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build Cerberus
 on: [push]
 jobs:
   run-build:
@@ -19,7 +19,3 @@ jobs:
             echo "The application has failed to build."
             exit 1  # This will cause the workflow to fail
             fi
-
-      - name: List Files
-        run: |
-            ls -a

--- a/.github/workflows/build-cerberus.yml
+++ b/.github/workflows/build-cerberus.yml
@@ -15,8 +15,10 @@ jobs:
       - name: Clone Embedded-base
         uses: actions/checkout@v3
         with:
-          repository: Northeastern-Electric-Racing/Embedded-Base
           path: "./Drivers/"
+
+      - name: "List files"
+        run: "tree"
 
       - name: Execute Make
         run: |

--- a/.github/workflows/build-cerberus.yml
+++ b/.github/workflows/build-cerberus.yml
@@ -18,7 +18,7 @@ jobs:
           path: "./Drivers/"
 
       - name: "List files"
-        run: "tree"
+        run: "ls ./Drivers"
 
       - name: Execute Make
         run: |

--- a/.github/workflows/build-cerberus.yml
+++ b/.github/workflows/build-cerberus.yml
@@ -8,10 +8,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Clone Cerberus
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: Northeastern-Electric-Racing/Cerberus
-          submodules: 'true'
+
+      - name: Clone Embedded-base
+        uses: actions/checkout@v3
+        with:
+          path: "./Drivers"
 
       - name: Execute Make
         run: |

--- a/.github/workflows/build-cerberus.yml
+++ b/.github/workflows/build-cerberus.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Clone Embedded-base
         uses: actions/checkout@v3
         with:
-          path: "./Drivers/"
+          path: "./Drivers/Embedded-Base"
 
       - name: "List files"
         run: "ls ./Drivers"

--- a/.github/workflows/build-cerberus.yml
+++ b/.github/workflows/build-cerberus.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Northeastern-Electric-Racing/Embedded-Base
-          path: "./Drivers"
+          path: "./Drivers/"
 
       - name: Execute Make
         run: |

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Northeastern-Electric-Racing/Cerberus
+          submodules: 'true'
 
       - name: Execute Make
         run: |

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Clone Cerberus
         uses: actions/checkout@v2
         with:
-          repository: Cerberus
+          repository: Northeastern-Electric-Racing/Cerberus
           submodules: recursive
 
       - name: Execute Make

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -8,10 +8,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Clone Cerberus
-      uses: actions/checkout@v2
-      with:
-        repository: Cerberus
-        submodules: recursive
+        uses: actions/checkout@v2
+        with:
+          repository: Cerberus
+          submodules: recursive
 
       - name: Execute Make
         run: |

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -11,7 +11,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Northeastern-Electric-Racing/Cerberus
-          submodules: recursive
 
       - name: Execute Make
         run: |
@@ -19,3 +18,7 @@ jobs:
             echo "The application has failed to build."
             exit 1  # This will cause the workflow to fail
             fi
+
+      - name: List Files
+        run: |
+            ls -a

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,21 @@
+name: Build
+on: [push]
+jobs:
+  run-build:
+    runs-on: ubuntu-latest
+    container:
+        image: nwdepatie/ner-gcc-arm:latest
+    timeout-minutes: 10
+    steps:
+      - name: Clone Cerberus
+      uses: actions/checkout@v2
+      with:
+        repository: Cerberus
+        submodules: recursive
+
+      - name: Execute Make
+        run: |
+            if ! make; then
+            echo "The application has failed to build."
+            exit 1  # This will cause the workflow to fail
+            fi


### PR DESCRIPTION
I've made a GitHub Action to automatically detect if a certain commit is compatible with Cerberus. An equivalent one should be made once Shepherd is in a buildable state