### PR TITLE
sync imu names

### DIFF
--- a/general/include/lsm6dso.h
+++ b/general/include/lsm6dso.h
@@ -87,7 +87,7 @@ HAL_StatusTypeDef lsm6dso_init(lsm6dso_t *imu, I2C_HandleTypeDef *i2c_handle);
  * @param lp_f2_enable
  * @return HAL_StatusTypeDef
  */
-HAL_StatusTypeDef lsm6dso_accelerometer_config(lsm6dso_t *imu, int8_t odr_sel, int8_t fs_sel, int8_t lp_f2_enable);
+HAL_StatusTypeDef lsm6dso_set_accel_cfg(lsm6dso_t *imu, int8_t odr_sel, int8_t fs_sel, int8_t lp_f2_enable);
 
 /**
  * @brief Configures the accelerometer of the LSM6DSO IMU
@@ -98,7 +98,7 @@ HAL_StatusTypeDef lsm6dso_accelerometer_config(lsm6dso_t *imu, int8_t odr_sel, i
  * @param fs_125
  * @return HAL_StatusTypeDef
  */
-HAL_StatusTypeDef lsm6dso_gyroscope_config(lsm6dso_t *imu, int8_t odr_sel, int8_t fs_sel, int8_t fs_125);
+HAL_StatusTypeDef lsm6dso_set_gyro_cfg(lsm6dso_t *imu, int8_t odr_sel, int8_t fs_sel, int8_t fs_125);
 
 /* Data Aquisition */
 /**

--- a/general/src/lsm6dso.c
+++ b/general/src/lsm6dso.c
@@ -106,7 +106,7 @@ HAL_StatusTypeDef lsm6dso_init(lsm6dso_t *imu, I2C_HandleTypeDef *i2c_handle)
 	if (status != HAL_OK)
 		return status;
 
-	status = lsm6dso_gyro_cfg(imu, 0x08, 0x02, 0x00);
+	status = lsm6dso_set_gyro_cfg(imu, 0x08, 0x02, 0x00);
 	if (status != HAL_OK)
 		return status;
 

--- a/general/src/lsm6dso.c
+++ b/general/src/lsm6dso.c
@@ -71,7 +71,7 @@ HAL_StatusTypeDef lsm6dso_set_accel_cfg(lsm6dso_t *imu, int8_t odr_sel, int8_t f
 	return lsm6dso_write_reg(imu, LSM6DSO_REG_ACCEL_CTRL, &imu->accel_config);
 }
 
-HAL_StatusTypeDef lsm6dso_gyro_cfg(lsm6dso_t *imu, int8_t odr_sel, int8_t fs_sel, int8_t fs_125)
+HAL_StatusTypeDef lsm6dso_set_gyro_cfg(lsm6dso_t *imu, int8_t odr_sel, int8_t fs_sel, int8_t fs_125)
 {
 	uint8_t config = (((odr_sel << 4) | (fs_sel << 2) | (fs_125 << 1)) << 1);
 	imu->gyro_config = config;


### PR DESCRIPTION
synced function names in the imu so that it wouldnt throw an undefined error when i try to use it in cerberus