### PR TITLE
added timer.h/.c

### DIFF
--- a/middleware/include/timer.h
+++ b/middleware/include/timer.h
@@ -4,7 +4,6 @@
 #include "stm32f4xx_hal.h"
 
 typdef struct {
-  uint32_t duration;
   uint32_t start_time;
   uint32_t end_time;
   bool active;
@@ -15,7 +14,7 @@ typdef struct {
  *
  * @param timer The timer to act on
  */
-void start_timer(timer_t *timer);
+void start_timer(timer_t *timer, uint32_t duration);
 
 /**
  * @brief cancels an active timer

--- a/middleware/include/timer.h
+++ b/middleware/include/timer.h
@@ -1,0 +1,44 @@
+#ifndef TIMER_H
+#define TIMER_H
+
+#include "stm32f4xx_hal.h"
+
+typdef struct {
+  uint32_t duration;
+  uint32_t start_time;
+  uint32_t end_time;
+  bool active;
+} timer_t;
+
+/**
+ * @brief Starts a timer of the given lenth
+ *
+ * @param timer The timer to act on
+ */
+void start_timer(timer_t *timer);
+
+/**
+ * @brief cancels an active timer
+ * 
+ * @param timer The timer to act on
+*/
+void cancel_timer(timer_t *timer);
+
+/**
+ * @brief Checks if the timer has expired
+ * 
+ * @param timer The timer to act on
+ * @return true if the timer has expired, false otherwise
+*/
+bool is_timer_expired(timer_t *timer);
+
+/**
+ * @brief Checks if the timer is active
+ * 
+ * @param timer The timer to act on
+ * @return true if the timer is active, false otherwise
+*/
+bool is_timer_active(timer_t *timer);
+
+
+#endif // TIMER_H

--- a/middleware/include/timer.h
+++ b/middleware/include/timer.h
@@ -7,6 +7,7 @@ typdef struct {
   uint32_t start_time;
   uint32_t end_time;
   bool active;
+  bool completed;
 } timer_t;
 
 /**

--- a/middleware/src/timer.c
+++ b/middleware/src/timer.c
@@ -6,11 +6,13 @@ void start_timer(timer_t *timer, uint32_t duration)
     timer->start_time = HAL_GetTick();
     timer->end_time = timer->start_time + duration;
     timer->active = true;
+    timer->completed = false;
 }
 
 void cancel_timer(timer_t *timer)
 {
     timer->active = false;
+    timer->completed = false;
 }
 
 bool is_timer_expired(timer_t *timer)
@@ -20,10 +22,10 @@ bool is_timer_expired(timer_t *timer)
         if (HAL_GetTick() >= timer->end_time)
         {
             timer->active = false;
-            return true;
+            timer->completed = true;
         }
     }
-    return false;
+    return timer->completed;
 }
 
 bool is_timer_active(timer_t *timer);

--- a/middleware/src/timer.c
+++ b/middleware/src/timer.c
@@ -1,10 +1,10 @@
 #include "timer.h"
 
-void start_timer(timer_t *timer)
+void start_timer(timer_t *timer, uint32_t duration)
 {
     /* this function assumes tick set to default 1 ms. Update or use HAL_GetTickFreq() if not the case */
     timer->start_time = HAL_GetTick();
-    timer->end_time = timer->start_time + timer->duration;
+    timer->end_time = timer->start_time + duration;
     timer->active = true;
 }
 

--- a/middleware/src/timer.c
+++ b/middleware/src/timer.c
@@ -1,0 +1,32 @@
+#include "timer.h"
+
+void start_timer(timer_t *timer)
+{
+    /* this function assumes tick set to default 1 ms. Update or use HAL_GetTickFreq() if not the case */
+    timer->start_time = HAL_GetTick();
+    timer->end_time = timer->start_time + timer->duration;
+    timer->active = true;
+}
+
+void cancel_timer(timer_t *timer)
+{
+    timer->active = false;
+}
+
+bool is_timer_expired(timer_t *timer)
+{
+    if (timer->active)
+    {
+        if (HAL_GetTick() >= timer->end_time)
+        {
+            timer->active = false;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool is_timer_active(timer_t *timer);
+{
+    return timer->active;
+}


### PR DESCRIPTION
Added timer functionality to repo. Should work for all chips, but does rely on specific reference to stmf4xx library (as all do). Not sure if middleware is best spot, feel free to suggest other location.

Plan to add more throughou error handling in future, both through STM HAL errors, and for addressing things like trying to read from inactive timer, etc. For now just want bare minimum functionality. 

Also, this ideally replaced both the NErduino timer class and the "Tri-state timer" struct i previously made in shepherd. Im not a fan of that, and the funcitonality can be replaced by just utilized the is_active" param properly. 