### PR TITLE
Moving macros to source files, linking to PDU implemnetation

### DIFF
--- a/general/include/pi4ioe.h
+++ b/general/include/pi4ioe.h
@@ -13,19 +13,6 @@
 #include "stm32f4xx_hal.h"
 #include "stm32f4xx_hal_i2c.h"
 
-// all of these addresses are complete bullshit and wrong plz fix when know :) and remove this comment
-// the values should be correct though, just the order is wrong
-
-#define PI4IOE_I2C_ADDR 	0x20 //? @hamza does HAL driver handle shifting for read/write bit automatically? if not should be added here
-
-#define IO_CONFIG_REG 		0x06
-#define IO_CONFIG_BUF 		0x10 /* = 0001 0000, bit 4 = TSMS = input */
-#define INPUT0_REG 			0x00
-#define INPUT1_REG 			0x01
-#define OUTPUT0_REG 		0x02
-#define OUTPUT1_REG 		0x03
-
-
 typedef struct
 {
 	I2C_HandleTypeDef *i2c_handle;

--- a/general/src/pi4ioe.c
+++ b/general/src/pi4ioe.c
@@ -7,6 +7,18 @@
 */
 #include "pi4ioe.h"
 
+// all of these addresses are complete bullshit and wrong plz fix when know :) and remove this comment
+// the values should be correct though, just the order is wrong
+
+#define PI4IOE_I2C_ADDR 	0x20 //? @hamza does HAL driver handle shifting for read/write bit automatically? if not should be added here
+
+#define IO_CONFIG_REG 		0x06
+#define IO_CONFIG_BUF 		0x10 /* = 0001 0000, bit 4 = TSMS = input */
+#define INPUT0_REG 			0x00
+#define INPUT1_REG 			0x01
+#define OUTPUT0_REG 		0x02
+#define OUTPUT1_REG 		0x03
+
 uint8_t oreg_1_data;
 uint8_t oreg_2_data;
 


### PR DESCRIPTION
This links to the Cerberus ticket to implement the PDU, but there are a bunch of PDU specific macros. I've moved the macros to the source files since the developer shouldn't care about these macros and it is only used for internal implementations.