### PR TITLE
Adding the ability to create multiple CAN callbacks

### DIFF
--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -8,13 +8,16 @@
 #include "stm32f4xx_hal.h"
 #include "stm32f4xx_hal_can.h"
 
+/* function pointer type for the callback */
+typedef void (*can_callback_t)(CAN_HandleTypeDef *hcan);
+
 typedef struct{
 	CAN_HandleTypeDef *hcan;
 	uint16_t *id_list;
 	uint8_t id_list_len;
 
 	/* desired behavior varies by app - so implement this at app level */
-	void (*can_callback)(CAN_HandleTypeDef *hcan);
+	can_callback_t callback;
 } can_t;
 
 typedef struct{
@@ -22,9 +25,6 @@ typedef struct{
 	uint8_t data[8];
 	uint8_t len;
 } can_msg_t;
-
-/* function pointer type for the callback */
-typedef void (*can_callback)(CAN_HandleTypeDef *hcan);
 
 HAL_StatusTypeDef can_init(can_t *can, can_callback callback);
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -26,7 +26,7 @@ typedef struct{
 	uint8_t len;
 } can_msg_t;
 
-HAL_StatusTypeDef can_init(can_t *can, can_callback_t callback);
+HAL_StatusTypeDef can_init(can_t *can);
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);
 
 #endif // CAN_H

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -26,7 +26,7 @@ typedef struct{
 	uint8_t len;
 } can_msg_t;
 
-HAL_StatusTypeDef can_init(can_t *can, can_callback callback);
+HAL_StatusTypeDef can_init(can_t *can, can_callback_t callback);
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);
 
 #endif // CAN_H

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -7,28 +7,26 @@
 
 #include "stm32f4xx_hal.h"
 #include "stm32f4xx_hal_can.h"
-typedef struct{
-    CAN_HandleTypeDef *hcan;
-    uint16_t *id_list;
-    uint8_t size;
 
-    /* desired behavior varies by app - so implement this at app level */
-    void (*can_callback)(CAN_HandleTypeDef *hcan);
+typedef struct{
+	CAN_HandleTypeDef *hcan;
+	uint16_t *id_list;
+	uint8_t id_list_len;
+
+	/* desired behavior varies by app - so implement this at app level */
+	void (*can_callback)(CAN_HandleTypeDef *hcan);
 } can_t;
 
 typedef struct{
-    uint16_t id;
-    uint8_t data[8];
-    uint8_t size;
+	uint16_t id;
+	uint8_t data[8];
+	uint8_t len;
 } can_msg_t;
 
-HAL_StatusTypeDef can_init(can_t *can);
+/* function pointer type for the callback */
+typedef void (*can_callback)(CAN_HandleTypeDef *hcan);
+
+HAL_StatusTypeDef can_init(can_t *can, can_callback callback);
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);
-
-
-
-
-
-
 
 #endif // CAN_H

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -51,7 +51,7 @@ HAL_StatusTypeDef can_init(can_t *can, can_callback callback)
 	uint16_t high_id = can->id_list[0];
 	uint16_t low_id = can->id_list[0];
 
-	for (uint8_t i = 0; i < can->size; i++) {
+	for (uint8_t i = 0; i < can->id_list_len; i++) {
 		if (can->id_list[i] > high_id)
 			high_id = can->id_list[i];
 		if (can->id_list[i] < low_id)

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -1,84 +1,67 @@
 #include "can.h"
 
-// function pointer type for the callback
-typedef void (*CAN_Callback)(CAN_HandleTypeDef *hcan);
-CAN_Callback myCANCallback;
-
-void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan)
+HAL_StatusTypeDef can_init(can_t *can, can_callback callback)
 {
-  // Handle CAN reception event
-  if (myCANCallback != NULL)
-  {
-    myCANCallback(hcan);
-  }
-}
-HAL_StatusTypeDef can_init(can_t *can)
-{
-    /* set up filter */
-    uint16_t high_id = can->id_list[0];
-    uint16_t low_id = can->id_list[0];
+	/* set up filter */
+	uint16_t high_id = can->id_list[0];
+	uint16_t low_id = can->id_list[0];
 
-    for (uint8_t i = 0; i < can->size; i++)
-    {
-        if (can->id_list[i] > high_id)
-        {
-            high_id = can->id_list[i];
-        }
-        if (can->id_list[i] < low_id)
-        {
-            low_id = can->id_list[i];
-        }
-    }
+	for (uint8_t i = 0; i < can->size; i++) {
+		if (can->id_list[i] > high_id)
+			high_id = can->id_list[i];
+		if (can->id_list[i] < low_id)
+			low_id = can->id_list[i];
+	}
 
-    uint32_t full_id = ((uint32_t)high_id << 16) | low_id;
+	uint32_t full_id = ((uint32_t)high_id << 16) | low_id;
 
-    CAN_FilterTypeDef sFilterConfig;
+	CAN_FilterTypeDef sFilterConfig;
 
-    sFilterConfig.FilterBank = 0;                       // Filter bank number (0 to 27 for most STM32 series)
-    sFilterConfig.FilterMode = CAN_FILTERMODE_IDLIST;   // Identifier list mode
-    sFilterConfig.FilterScale = CAN_FILTERSCALE_32BIT;  // 32-bit identifier list
+	sFilterConfig.FilterBank = 0;                       /* Filter bank number (0 to 27 for most STM32 series) */
+	sFilterConfig.FilterMode = CAN_FILTERMODE_IDLIST;   /* Identifier list mode */
+	sFilterConfig.FilterScale = CAN_FILTERSCALE_32BIT;  /* 32-bit identifier list */
 
-    sFilterConfig.FilterIdHigh = (full_id & 0xFFFF0000U) >> 5;
-    sFilterConfig.FilterIdLow = (full_id & 0xFFFFU) << 5;
+	sFilterConfig.FilterIdHigh = (full_id & 0xFFFF0000U) >> 5;
+	sFilterConfig.FilterIdLow = (full_id & 0xFFFFU) << 5;
 
-    sFilterConfig.FilterMaskIdHigh = 0xFFFF << 5;       // Set to all ones for ID range
-    sFilterConfig.FilterMaskIdLow = 0xFFFF;             // Set to all ones for ID range
+	sFilterConfig.FilterMaskIdHigh = 0xFFFF << 5;       /* Set to all ones for ID range */
+	sFilterConfig.FilterMaskIdLow = 0xFFFF;             /* Set to all ones for ID range */
 
-    sFilterConfig.FilterFIFOAssignment = CAN_RX_FIFO0;  // FIFO to assign the filter to
-    sFilterConfig.FilterActivation = ENABLE;            // Enable the filter
+	sFilterConfig.FilterFIFOAssignment = CAN_RX_FIFO0;  /* FIFO to assign the filter to */
+	sFilterConfig.FilterActivation = ENABLE;            /* Enable the filter */
 
-    uint8_t err = 0;
-    err = HAL_CAN_ConfigFilter(&can->hcan, &sFilterConfig);
-    if (err != HAL_OK) return err;
+	uint8_t err = 0;
+	err = HAL_CAN_ConfigFilter(&can->hcan, &sFilterConfig);
+	if (err != HAL_OK)
+		return err;
 
-    /* set up interrupt & activate CAN */
-    err = HAL_CAN_Start(can->hcan);
-    if (err != HAL_OK) return err;
+	/* set up interrupt & activate CAN */
+	err = HAL_CAN_Start(can->hcan);
+	if (err != HAL_OK)
+		return err;
 
-    // Override the default callback for CAN_IT_RX_FIFO0_MSG_PENDING
-    myCANCallback = can->can_callback;
-    err = HAL_CAN_ActivateNotification(can->hcan, CAN_IT_RX_FIFO0_MSG_PENDING);
+	/* Override the default callback for CAN_IT_RX_FIFO0_MSG_PENDING */
+	err = HAL_CAN_ActivateNotification(can->hcan, callback);
+	can->can_callback = callback;
 
-    return err;
+	return err;
 }
 
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
 {
-    CAN_TxHeaderTypeDef tx_header;
-    tx_header.StdId = msg->id;
-    tx_header.ExtId = 0;
-    tx_header.IDE = CAN_ID_STD;
-    tx_header.RTR = CAN_RTR_DATA;
-    tx_header.DLC = msg->size;
-    tx_header.TransmitGlobalTime = DISABLE;
+	CAN_TxHeaderTypeDef tx_header;
+	tx_header.StdId = msg->id;
+	tx_header.ExtId = 0;
+	tx_header.IDE = CAN_ID_STD;
+	tx_header.RTR = CAN_RTR_DATA;
+	tx_header.DLC = msg->size;
+	tx_header.TransmitGlobalTime = DISABLE;
 
-    uint32_t tx_mailbox;
-    HAL_CAN_AddTxMessage(can->hcan, &tx_header, msg->data, &tx_mailbox);
+	uint32_t tx_mailbox;
+	HAL_CAN_AddTxMessage(can->hcan, &tx_header, msg->data, &tx_mailbox);
 
-    if (HAL_CAN_GetTxMailboxesFreeLevel(can->hcan) == 0)
-    {
-        return HAL_ERROR;
-    }
+	if (HAL_CAN_GetTxMailboxesFreeLevel(can->hcan) == 0)
+		return HAL_ERROR;
 
-    return HAL_OK;
+	return HAL_OK;
 }

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -1,4 +1,49 @@
 #include "can.h"
+#include <string.h>
+
+/* NOTE: STM32F405 will have MAX of 3 CAN buses */
+#define MAX_CAN_BUS	3
+
+can_t *can_struct_list[MAX_CAN_BUS] = {NULL, NULL, NULL};
+
+static can_callback_t find_callback(CAN_HandleTypeDef *hcan)
+{
+	for (uint8_t i = 0; i < MAX_CAN_BUS; i++) {
+		if (hcan == can_struct_list[i]->hcan)
+			return can_struct_list[i]->callback;
+	}
+	return NULL;
+}
+
+/* Add a CAN interfae to be searched for during the event of a callback */
+static uint8_t add_interface(can_t *interface)
+{
+	for (uint8_t i = 0; i < MAX_CAN_BUS; i++) {
+		/* Interface already added */
+		if (interface->hcan == can_struct_list[i]->hcan)
+			return -1;
+
+		/* If empty, add interface */
+		if (can_struct_list[i]->hcan == NULL) {
+			can_struct_list[i] = interface;
+			return 0;
+		}
+	}
+
+	/* No open slots, something is wrong */
+	return -2;
+}
+
+void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan)
+{
+	/* Handle CAN reception event */
+	can_callback_t callback= find_callback(hcan);
+
+	if (callback != NULL)
+	{
+		callback(hcan);
+	}
+}
 
 HAL_StatusTypeDef can_init(can_t *can, can_callback callback)
 {
@@ -41,8 +86,8 @@ HAL_StatusTypeDef can_init(can_t *can, can_callback callback)
 		return err;
 
 	/* Override the default callback for CAN_IT_RX_FIFO0_MSG_PENDING */
-	err = HAL_CAN_ActivateNotification(can->hcan, callback);
-	can->can_callback = callback;
+	err = HAL_CAN_ActivateNotification(can->hcan, CAN_IT_RX_FIFO0_MSG_PENDING);
+	err = add_interface(can);
 
 	return err;
 }

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -1,5 +1,6 @@
 #include "can.h"
 #include <string.h>
+#include <stdint.h>
 
 /* NOTE: STM32F405 will have MAX of 3 CAN buses */
 #define MAX_CAN_BUS	3
@@ -45,7 +46,7 @@ void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan)
 	}
 }
 
-HAL_StatusTypeDef can_init(can_t *can, can_callback callback)
+HAL_StatusTypeDef can_init(can_t *can, can_callback_t callback)
 {
 	/* set up filter */
 	uint16_t high_id = can->id_list[0];
@@ -99,7 +100,7 @@ HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
 	tx_header.ExtId = 0;
 	tx_header.IDE = CAN_ID_STD;
 	tx_header.RTR = CAN_RTR_DATA;
-	tx_header.DLC = msg->size;
+	tx_header.DLC = msg->len;
 	tx_header.TransmitGlobalTime = DISABLE;
 
 	uint32_t tx_mailbox;

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -46,7 +46,7 @@ void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan)
 	}
 }
 
-HAL_StatusTypeDef can_init(can_t *can, can_callback_t callback)
+HAL_StatusTypeDef can_init(can_t *can)
 {
 	/* set up filter */
 	uint16_t high_id = can->id_list[0];


### PR DESCRIPTION
Before we only were able to have 1 callback across all lines (i.e. global value), but now we are linking the callback to each hcan struct