### PR TITLE
Fixing some minor errors with ringbuffer implementation

### DIFF
--- a/middleware/include/ringbuffer.h
+++ b/middleware/include/ringbuffer.h
@@ -19,6 +19,6 @@ void ringbuffer_destroy(ringbuffer_t* rb);
 int ringbuffer_is_empty(ringbuffer_t* rb);
 int ringbuffer_is_full(ringbuffer_t* rb);
 int ringbuffer_enqueue(ringbuffer_t* rb, void* data);
-void *ringbuffer_dequeue(ringbuffer_t* rb);
+void ringbuffer_dequeue(ringbuffer_t* rb, void* data);
 
 #endif // RINGBUFFER_H

--- a/middleware/include/ringbuffer.h
+++ b/middleware/include/ringbuffer.h
@@ -19,6 +19,6 @@ void ringbuffer_destroy(ringbuffer_t* rb);
 int ringbuffer_is_empty(ringbuffer_t* rb);
 int ringbuffer_is_full(ringbuffer_t* rb);
 int ringbuffer_enqueue(ringbuffer_t* rb, void* data);
-void* ringbuffer_dequeue(ringbuffer_t* rb, void* data);
+void ringbuffer_dequeue(ringbuffer_t* rb, void* data);
 
 #endif // RINGBUFFER_H

--- a/middleware/include/ringbuffer.h
+++ b/middleware/include/ringbuffer.h
@@ -19,6 +19,6 @@ void ringbuffer_destroy(ringbuffer_t* rb);
 int ringbuffer_is_empty(ringbuffer_t* rb);
 int ringbuffer_is_full(ringbuffer_t* rb);
 int ringbuffer_enqueue(ringbuffer_t* rb, void* data);
-void ringbuffer_dequeue(ringbuffer_t* rb, void* data);
+void *ringbuffer_dequeue(ringbuffer_t* rb);
 
 #endif // RINGBUFFER_H

--- a/middleware/src/ringbuffer.c
+++ b/middleware/src/ringbuffer.c
@@ -70,13 +70,12 @@ int ringbuffer_enqueue(ringbuffer_t* rb, void* data)
     return 0; // Successful enqueue
 }
 
-void *ringbuffer_dequeue(ringbuffer_t* rb) 
+void ringbuffer_dequeue(ringbuffer_t* rb, void* data) 
 {
-    void* data;
-
     if (ringbuffer_is_empty(rb)) {
         // Buffer is empty, cannot dequeue
-        return NULL;
+        data = NULL;
+        return;
     }
 
     // Copy the data from the buffer
@@ -87,5 +86,4 @@ void *ringbuffer_dequeue(ringbuffer_t* rb)
 
     rb->front = (rb->front + 1) % rb->capacity;
     rb->count--;
-    return data;
 }

--- a/middleware/src/ringbuffer.c
+++ b/middleware/src/ringbuffer.c
@@ -70,12 +70,13 @@ int ringbuffer_enqueue(ringbuffer_t* rb, void* data)
     return 0; // Successful enqueue
 }
 
-void ringbuffer_dequeue(ringbuffer_t* rb, void* data) 
+void *ringbuffer_dequeue(ringbuffer_t* rb) 
 {
+    void* data;
+
     if (ringbuffer_is_empty(rb)) {
         // Buffer is empty, cannot dequeue
-        data = NULL;
-        return;
+        return NULL;
     }
 
     // Copy the data from the buffer
@@ -86,4 +87,5 @@ void ringbuffer_dequeue(ringbuffer_t* rb, void* data)
 
     rb->front = (rb->front + 1) % rb->capacity;
     rb->count--;
+    return data;
 }

--- a/middleware/src/ringbuffer.c
+++ b/middleware/src/ringbuffer.c
@@ -1,12 +1,18 @@
 #include "ringbuffer.h"
 #include <string.h>
+#include <stdlib.h>
 
 ringbuffer_t* ringbuffer_create(size_t capacity, size_t element_size)
 {
-    ringbuffer_t* rb = (ringbuffer_t*)calloc(sizeof(rb));
-    if (rb == NULL) {
-
+    ringbuffer_t* rb = (ringbuffer_t*)malloc(sizeof(ringbuffer_t));
+    if (!rb) {
         // Handle memory allocation failure
+        return NULL;
+    }
+
+    rb->buffer = calloc(capacity, element_size);
+    if (!rb->buffer) {
+        free(rb);
         return NULL;
     }
 
@@ -64,10 +70,11 @@ int ringbuffer_enqueue(ringbuffer_t* rb, void* data)
     return 0; // Successful enqueue
 }
 
-void* ringbuffer_dequeue(ringbuffer_t* rb, void* data) 
+void ringbuffer_dequeue(ringbuffer_t* rb, void* data) 
 {
     if (ringbuffer_is_empty(rb)) {
         // Buffer is empty, cannot dequeue
+        data = NULL;
         return;
     }
 


### PR DESCRIPTION
I found some small errors I missed when trying to compile ringbuffer for Cerberus. Specifically:

* Forgot to include stdlib.h for malloc and calloc
* Never allocated memory for the buffer, tried to use calloc for the actual struct
* fixed return type of dequeue