### PR TITLE
made param const

### DIFF
--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -13,7 +13,7 @@ typedef void (*can_callback_t)(CAN_HandleTypeDef *hcan);
 
 typedef struct{
 	CAN_HandleTypeDef *hcan;
-	uint16_t *id_list;
+	const uint16_t *id_list;
 	uint8_t id_list_len;
 
 	/* desired behavior varies by app - so implement this at app level */


### PR DESCRIPTION
made ID list const, this should always be the case, and i want to stop being spammed with the warnings in shepherd since the id list being passed in by apps is going to be const