### PR TITLE
Fixing the address on lsm6dso to correct address

### DIFF
--- a/general/include/lsm6dso.h
+++ b/general/include/lsm6dso.h
@@ -12,7 +12,7 @@
 #include "stm32f4xx_hal.h"
 #include "stm32f4xx_hal_i2c.h"
 
-#define LSM6DSO_I2C_ADDRESS                 0x35 << 1   /* Shifted because datasheet said to */
+#define LSM6DSO_I2C_ADDRESS                 0x6A << 1   /* Shifted because datasheet said to */
 // Not sure if these are all needed, also not sure if more need to be added
 /* For register descriptions reference datasheet pages 47 - 98 */
 #define LSM6DSO_REG_FUNC_CFG_ACCESS         0x01    /* Enable embedded functions register */


### PR DESCRIPTION
## Changes

Fix for LSM6DSO driver to ping device ID

## Notes

Pretty simple fix, also validated on hardware
