### PR TITLE
removed ltc config from local --> app

### DIFF
--- a/general/include/ltc68041.h
+++ b/general/include/ltc68041.h
@@ -194,7 +194,7 @@ static const unsigned int crc15Table[256] = {
 #define DCP_DISABLED 0
 #define DCP_ENABLED 1
 
-ltc_config *LTC6804_initialize(SPI_HandleTypeDef *hspi, GPIO_TypeDef *hgpio, uint8_t cs_pin);
+void LTC6804_initialize(ltc_config* conf, SPI_HandleTypeDef *hspi, GPIO_TypeDef *hgpio, uint8_t cs_pin);
 
 void set_adc(uint8_t MD, uint8_t DCP, uint8_t CH, uint8_t CHG);
 

--- a/general/src/ltc68041.c
+++ b/general/src/ltc68041.c
@@ -71,8 +71,6 @@ Copyright 2013 Linear Technology Corp. (LTC)
 #include <stdlib.h>
 #include <stdio.h>
 
-ltc_config *ltcconfig;
-
 // TODO ensure shepherd app configures SPI with these settings:
 // const SPISettings ltcSPISettings = SPISettings(1000000, MSBFIRST, SPI_MODE3);
 
@@ -100,15 +98,15 @@ int8_t read_68(ltc_config *config, uint8_t total_ic,  uint8_t tx_cmd[2], uint8_t
   to convert all cell and GPIO voltages in the Normal ADC mode.
 */
 
-ltc_config *LTC6804_initialize(SPI_HandleTypeDef *hspi, GPIO_TypeDef *hgpio,
+void LTC6804_initialize(ltc_config* conf, *hspi, GPIO_TypeDef *hgpio,
                                uint8_t cs_pin) {
-  ltcconfig->spi = hspi;
-  ltcconfig->gpio = hgpio;
-  ltcconfig->cs_pin = cs_pin;
+  conf->spi = hspi;
+  conf->gpio = hgpio;
+  conf->cs_pin = cs_pin;
 
-  HAL_GPIO_WritePin(ltcconfig->gpio, ltcconfig->cs_pin, GPIO_PIN_SET);
+  HAL_GPIO_WritePin(conf->gpio, conf->cs_pin, GPIO_PIN_SET);
 
-  return ltcconfig;
+  return conf;
 
   // TODO make sure shepherd app configures ADC with these settings:
   // set_adc(MD_NORMAL,DCP_DISABLED,CELL_CH_ALL,AUX_CH_ALL);


### PR DESCRIPTION
## Changes

This simply restructured the ltc driver to accept the ltcconfig as a param instead of locally

## Notes

Worked when testing on board

## To Do
none

