### PR TITLE
Fixing alias issue with flashing and debug

### DIFF
--- a/dev/scripts/flash.sh
+++ b/dev/scripts/flash.sh
@@ -1,2 +1,6 @@
 #! /bin/bash
-openocd -f interface/cmsis-dap.cfg -f target/stm32f4x.cfg -c "adapter speed 5000" -c "program /home/app/build/*.elf verify reset exit"
+elf_file=$(ls /home/app/build/*.elf)
+
+printf "$elf_file"
+
+openocd -f interface/cmsis-dap.cfg -f target/stm32f4x.cfg -c "adapter speed 5000" -c "program $elf_file verify reset exit"

--- a/dev/scripts/gdb.sh
+++ b/dev/scripts/gdb.sh
@@ -1,2 +1,8 @@
 #! /bin/bash
-openocd -f interface/cmsis-dap.cfg -f target/stm32f4x.cfg -c "adapter speed 5000" -c "init" -c "reset halt" & sleep 1 && arm-none-eabi-gdb /home/app/build/*.elf -ex "target remote localhost:3333"
+elf_file=$(ls /home/app/build/*.elf)
+
+printf "$elf_file"
+
+openocd -f interface/cmsis-dap.cfg -f target/stm32f4x.cfg -c "adapter speed 5000" -c "init" -c "reset halt" & sleep 1 && arm-none-eabi-gdb $elf_file -ex "target remote localhost:3333"
+
+kill $(pidof openocd)


### PR DESCRIPTION
## Changes

My flashing alias didn't work, turns out openocd doesn't let you implement wildcards like bash into inputs
