### PR TITLE
Implementing more concise implementation of CAN callbacks

### DIFF
--- a/middleware/include/c_utils.h
+++ b/middleware/include/c_utils.h
@@ -1,0 +1,12 @@
+#ifndef C_UTILS
+#define C_UTILS
+
+/*
+ * Will retrieve the container of a certain pointer given the container type and its pointer
+ * Trick pulled from Linux Kernel
+ */
+#define container_of(ptr, type, member) ({                      \
+        const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
+        (type *)( (char *)__mptr - offsetof(type,member) );})
+
+#endif /* C_UTILS */

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -7,6 +7,7 @@
 
 #include "stm32f4xx_hal.h"
 #include "stm32f4xx_hal_can.h"
+#include "c_utils.h"
 
 /* function pointer type for the callback */
 typedef void (*can_callback_t)(CAN_HandleTypeDef *hcan);

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -9,16 +9,15 @@
 #include "stm32f4xx_hal_can.h"
 #include "c_utils.h"
 
-/* function pointer type for the callback */
-typedef void (*can_callback_t)(CAN_HandleTypeDef *hcan);
+/*
+ * NOTE: For implementing callbacks, generate NVIC for selected CAN bus, then implement in
+ * `stm32xxxx_it.c`, which STM32CubeMX generates
+ */
 
 typedef struct{
 	CAN_HandleTypeDef *hcan;
 	const uint16_t *id_list;
 	uint8_t id_list_len;
-
-	/* desired behavior varies by app - so implement this at app level */
-	can_callback_t callback;
 } can_t;
 
 typedef struct{

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -5,7 +5,7 @@
 void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan)
 {
 	/* Retrieve the container of the hcan struct then call the callback*/
-	can_t *can = container_of(hcan, can_t, hcan);
+	can_t *can = container_of(&hcan, can_t, hcan);
 	can->callback(hcan);
 }
 
@@ -34,7 +34,7 @@ HAL_StatusTypeDef can_init(can_t *can)
 	sFilterConfig.FilterMaskIdHigh = 0x0000;
 	sFilterConfig.FilterMaskIdLow = 0x0000;
 	sFilterConfig.FilterFIFOAssignment = CAN_RX_FIFO0;
-	sFilterConfig.FilterActivation = ENABLE;   
+	sFilterConfig.FilterActivation = ENABLE;
 	sFilterConfig.SlaveStartFilterBank = 14;
 
 	// sFilterConfig.FilterBank = 0;                       /* Filter bank number (0 to 27 for most STM32 series) */
@@ -55,18 +55,12 @@ HAL_StatusTypeDef can_init(can_t *can)
 	if (err != HAL_OK)
 		return err;
 
-	/* set up interrupt & activate CAN */
-	HAL_CAN_IRQHandler(can->hcan);
-	
 	err = HAL_CAN_ActivateNotification(can->hcan, CAN_IT_RX_FIFO0_MSG_PENDING);
 	if (err != HAL_OK)
 		return err;
 	err = HAL_CAN_Start(can->hcan);
 	if (err != HAL_OK)
 		return err;
-
-	/* Override the default callback for CAN_IT_RX_FIFO0_MSG_PENDING */
-	err = add_interface(can);
 
 	return err;
 }
@@ -89,9 +83,4 @@ HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
 		return HAL_ERROR;
 
 	return HAL_OK;
-}
-
-void CAN1_RX0_IRQHandler(void)
-{
-	HAL_CAN_IRQHandler(&hcan1);
 }

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -2,49 +2,11 @@
 #include <string.h>
 #include <stdint.h>
 
-/* NOTE: STM32F405 will have MAX of 3 CAN buses */
-#define MAX_CAN_BUS	3
-extern CAN_HandleTypeDef hcan1;
-
-can_t *can_struct_list[MAX_CAN_BUS] = {NULL, NULL, NULL};
-
-static can_callback_t find_callback(CAN_HandleTypeDef *hcan)
-{
-	for (uint8_t i = 0; i < MAX_CAN_BUS; i++) {
-		if (hcan == can_struct_list[i]->hcan)
-			return can_struct_list[i]->callback;
-	}
-	return NULL;
-}
-
-/* Add a CAN interfae to be searched for during the event of a callback */
-static uint8_t add_interface(can_t *interface)
-{
-	for (uint8_t i = 0; i < MAX_CAN_BUS; i++) {
-		/* Interface already added */
-		if (interface->hcan == can_struct_list[i]->hcan)
-			return -1;
-
-		/* If empty, add interface */
-		if (can_struct_list[i]->hcan == NULL) {
-			can_struct_list[i] = interface;
-			return 0;
-		}
-	}
-
-	/* No open slots, something is wrong */
-	return -2;
-}
-
 void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan)
 {
-	/* Handle CAN reception event */
-	can_callback_t callback = find_callback(hcan);
-
-	if (callback != NULL)
-	{
-		callback(hcan);
-	}
+	/* Retrieve the container of the hcan struct then call the callback*/
+	can_t *can = container_of(hcan, can_t, hcan);
+	can->callback(hcan);
 }
 
 HAL_StatusTypeDef can_init(can_t *can)

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -2,12 +2,10 @@
 #include <string.h>
 #include <stdint.h>
 
-void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan)
-{
-	/* Retrieve the container of the hcan struct then call the callback*/
-	can_t *can = container_of(&hcan, can_t, hcan);
-	can->callback(hcan);
-}
+/*
+ * NOTE: For implementing callbacks, generate NVIC for selected CAN bus, then implement in
+ * `stm32xxxx_it.c`, which STM32CubeMX generates
+ */
 
 HAL_StatusTypeDef can_init(can_t *can)
 {
@@ -54,6 +52,9 @@ HAL_StatusTypeDef can_init(can_t *can)
 	err = HAL_CAN_ConfigFilter(can->hcan, &sFilterConfig);
 	if (err != HAL_OK)
 		return err;
+
+	/* set up interrupt & activate CAN */
+	HAL_CAN_IRQHandler(can->hcan);
 
 	err = HAL_CAN_ActivateNotification(can->hcan, CAN_IT_RX_FIFO0_MSG_PENDING);
 	if (err != HAL_OK)


### PR DESCRIPTION
## Changes

Implementing our own `container_of` macro like the Linux Kernel has, and then using it for a better CAN callback implementation.

This is very very much not tested, I want to test on hardware before we merge in. I've used `container_of` a lot in the Linux Kernel and have been missing it in STM land, but just realized its one macro we could copy in. More info on what this macro does:
https://embetronicx.com/tutorials/p_language/c/understanding-of-container_of-macro-in-linux-kernel/

**NOTE** This did not work as intended lol. The macro itself works, but for this application it does not, see my comment below. 

## Notes

User should go through the normal method of declaring an interrupt in STM32CubeMX, which autogenerates a callback for each CAN bus. STM actually intends for the user to input code in these callbacks, meaning we should go through these routes rather than reinventing the wheel and making it harder for ourselves. See this PR for more context:https://github.com/Northeastern-Electric-Racing/Cerberus/pull/139

## Test Cases

- It builds in the context of Cerberus

## To Do

- [ ] Test on hardware

