### PR TITLE
Automatically build docker image

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -5,7 +5,7 @@ name: Create and publish a Docker image
 on:
   push:
     paths:
-        - './dev/**'
+        - 'dev/**'
   workflow_dispatch:
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,0 +1,50 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    paths:
+        - './dev/**'
+  workflow_dispatch:
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: ./dev/
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -32,7 +32,7 @@ COPY ./scripts .
 
 RUN echo "source /home/dev/scripts/alias.sh" >> ~/.bashrc
 
-# for usb/ip
+# for usb/ip comms and get binary symlinked
 EXPOSE 3240
 RUN ln -sf /usr/lib/linux-tools-*/* /usr/bin/
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get -y install tzdata
 
 # Download Linux support tools
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
     build-essential \
     wget \
     curl \


### PR DESCRIPTION
Auto build docker image with ghcr. Updates if anything in dev folder is changed, even across branches.  Those branches will have a different tag is all.

I am dumb apparently you can have public packages it is just very hidden in organization settings I only searched through repository settings.  Let me know if this works without authenticating, it worked for me I think.

Will add documentation switch to this with the eventual addition of compose.

Closes #52 