### PR TITLE
Yaml refresh

### DIFF
--- a/cangen/can-messages/charger.yaml
+++ b/cangen/can-messages/charger.yaml
@@ -5,21 +5,21 @@ msgs:
     desc: "BMS Message Send"
     fields:
     - !DiscreteField
-        name: "Charger/BMS/Voltage"
+        name: "BMS/Charging/Voltage"
         unit: "V"
         size: 16
         format: "current"
     - !DiscreteField
-        name: "Charger/BMS/Current"
+        name: "BMS/Charging/Current"
         unit: "A"
         size: 16
         format: "current"
     - !DiscreteField
-        name: "Charger/BMS/Control"
+        name: "BMS/Charging/Control"
         unit: ""
         size: 8
     - !DiscreteField
-        name: "Charger/Unimplemented/Data"
+        name: "BMS/Charging/UnimplementedData"
         unit: ""
         size: 24
 
@@ -60,6 +60,6 @@ msgs:
         unit: "bool"
         size: 1
     - !DiscreteField
-        name: "Charger/Unimplemented/Data"
+        name: "Charger/Box/UnimplementedData"
         unit: ""
         size: 24

--- a/cangen/can-messages/dti.yaml
+++ b/cangen/can-messages/dti.yaml
@@ -119,28 +119,9 @@ msgs:
         unit: "%"
         size: 8
         signed: true
+# NOTE: DTI sends bits in reverse order of how they appear in documentation
     - !DiscreteField
-        name: "DTI/General/Digital_In_1"
-        unit: ""
-        size: 1
-    - !DiscreteField
-        name: "DTI/General/Digital_In_2"
-        unit: ""
-        size: 1
-    - !DiscreteField
-        name: "DTI/General/Digital_In_3"
-        unit: ""
-        size: 1
-    - !DiscreteField
-        name: "DTI/General/Digital_In_4"
-        unit: ""
-        size: 1
-    - !DiscreteField
-        name: "DTI/General/Digital_Out_1"
-        unit: ""
-        size: 1
-    - !DiscreteField
-        name: "DTI/General/Digital_Out_2"
+        name: "DTI/General/Digital_Out_4"
         unit: ""
         size: 1
     - !DiscreteField
@@ -148,36 +129,37 @@ msgs:
         unit: ""
         size: 1
     - !DiscreteField
-        name: "DTI/General/Digital_Out_4"
+        name: "DTI/General/Digital_Out_2"
         unit: ""
         size: 1
+    - !DiscreteField
+        name: "DTI/General/Digital_Out_1"
+        unit: ""
+        size: 1
+    - !DiscreteField
+        name: "DTI/General/Digital_In_4"
+        unit: ""
+        size: 1
+    - !DiscreteField
+        name: "DTI/General/Digital_In_3"
+        unit: ""
+        size: 1
+    - !DiscreteField
+        name: "DTI/General/Digital_In_2"
+        unit: ""
+        size: 1
+    - !DiscreteField
+        name: "DTI/General/Digital_In_1"
+        unit: ""
+        size: 1
+# NEW BYTE
     - !DiscreteField
         name: "DTI/General/Drive_Enable"
         unit: ""
         size: 8
-        signed: false
+# NEW BYTE
     - !DiscreteField
-        name: "DTI/Limit/Cap_Temp_Limit"
-        unit: ""
-        size: 1
-    - !DiscreteField
-        name: "DTI/Limit/DC_Current_Limit"
-        unit: ""
-        size: 1
-    - !DiscreteField
-        name: "DTI/Limit/Drive_Enable_Limit"
-        unit: ""
-        size: 1
-    - !DiscreteField
-        name: "DTI/Limit/IGBT_Acc_Temp_Limit"
-        unit: ""
-        size: 1
-    - !DiscreteField
-        name: "DTI/Limit/IGBT_Temp_Limit"
-        unit: ""
-        size: 1
-    - !DiscreteField
-        name: "DTI/Limit/Input_Voltage_Limit"
+        name: "DTI/Limit/Motor_Temp_Limit"
         unit: ""
         size: 1
     - !DiscreteField
@@ -185,11 +167,32 @@ msgs:
         unit: ""
         size: 1
     - !DiscreteField
-        name: "DTI/Limit/Motor_Temp_Limit"
+        name: "DTI/Limit/Input_Voltage_Limit"
         unit: ""
         size: 1
     - !DiscreteField
-        name: "DTI/Limit/RPM_Min_Limit"
+        name: "DTI/Limit/IGBT_Temp_Limit"
+        unit: ""
+        size: 1
+    - !DiscreteField
+        name: "DTI/Limit/IGBT_Acc_Temp_Limit"
+        unit: ""
+        size: 1
+    - !DiscreteField
+        name: "DTI/Limit/Drive_Enable_Limit"
+        unit: ""
+        size: 1
+    - !DiscreteField
+        name: "DTI/Limit/DC_Current_Limit"
+        unit: ""
+        size: 1
+    - !DiscreteField
+        name: "DTI/Limit/Cap_Temp_Limit"
+        unit: ""
+        size: 1
+# NEW BYTE - NOTE, this byte may be wrong due to bit stuff
+    - !DiscreteField
+        name: "DTI/Limit/Power_Limit"
         unit: ""
         size: 1
     - !DiscreteField
@@ -197,7 +200,7 @@ msgs:
         unit: ""
         size: 1
     - !DiscreteField
-        name: "DTI/Limit/Power_Limit"
+        name: "DTI/Limit/RPM_Min_Limit"
         unit: ""
         size: 1
     - !DiscreteField
@@ -207,20 +210,20 @@ msgs:
     - !DiscreteField
         name: "DTI/Unused/Reserved"
         unit: ""
-        size: 1
+        size: 8
     - !DiscreteField
         name: "DTI/General/CAN_Map_Version"
         unit: ""
-        size: 1
+        size: 8
        
             
-#DTI_COMMAND
+#DTI_COMMAND - Known MPU
 - !CANMsg
     id: "0x036"
     desc: "AC_Current_Command"
     fields:
     - !DiscreteField
-        name: "DTI/Commands/AC_Current_Target"
+        name: "MPU/Commands/AC_Current_Target"
         unit: "A"
         size: 16
         signed: true
@@ -338,13 +341,13 @@ msgs:
         unit: ""
         size: 60
 
-#DTI_COMMAND
+#DTI_COMMAND - Assumed BMS
 - !CANMsg
     id: "0x116"
     desc: "Max_AC_Current_Command"
     fields:
     - !DiscreteField
-        name: "DTI/Commands/Max_AC_Current_Target"
+        name: "BMS/Commands/Max_AC_Current_Target"
         unit: "A"
         size: 16
         signed: true
@@ -355,13 +358,13 @@ msgs:
         unit: ""
         size: 48
 
-#DTI_COMMAND
+#DTI_COMMAND - Assumed BMS
 - !CANMsg
     id: "0x136"
     desc: "Max_AC_Brake_Current_Command"
     fields:
     - !DiscreteField
-        name: "DTI/Commands/Max_AC_Brake_Current_Target"
+        name: "BMS/Commands/Max_AC_Brake_Current_Target"
         unit: "A"
         size: 16
         signed: true
@@ -372,37 +375,37 @@ msgs:
         unit: ""
         size: 48
 
-#DTI_COMMAND
+#DTI_COMMAND - Known BMS
 - !CANMsg
     id: "0x156"
     desc: "Max_DC_Current_Command"
     fields:
     - !DiscreteField
-        name: "DTI/Commands/Max_DC_Current_Target"
+        name: "BMS/Commands/Max_DC_Current_Target"
         unit: "A"
         size: 16
         signed: true
         format: "current"
 
-#DTI_COMMAND
+#DTI_COMMAND - Known BMS
 - !CANMsg
     id: "0x176"
     desc: "Max_DC_Brake_Current_Command"
     fields:
     - !DiscreteField
-        name: "DTI/Commands/Max_DC_Brake_Current_Target"
+        name: "BMS/Commands/Max_DC_Brake_Current_Target"
         unit: "A"
         size: 16
         signed: true
         format: "current"
 
-#DTI_COMMAND
+#DTI_COMMAND - Known MPU
 - !CANMsg
     id: "0x196"
     desc: "Drive_Enable_Command"
     fields:
     - !DiscreteField
-        name: "DTI/Commands/Drive_Enable_Target"
+        name: "MPU/Commands/Drive_Enable_Target"
         unit: ""
         size: 8
 

--- a/middleware/include/c_utils.h
+++ b/middleware/include/c_utils.h
@@ -13,3 +13,9 @@
 
 
 void endian_swap(void *ptr, int size);
+
+
+/// @brief Reverses the bit order of a byte
+/// @param b byte
+/// @return the same byte but wuth the bits reversed
+unsigned char reverse_bits(unsigned char b);

--- a/middleware/src/c_utils.c
+++ b/middleware/src/c_utils.c
@@ -12,3 +12,13 @@ void endian_swap(void *ptr, int size)
         p[size-i-1] = tmp;
     }
 }
+
+/// @brief Reverses the bit order of a byte
+/// @param b byte
+/// @return the same byte but wuth the bits reversed
+unsigned char reverse(unsigned char b) {
+   b = (b & 0xF0) >> 4 | (b & 0x0F) << 4;
+   b = (b & 0xCC) >> 2 | (b & 0x33) << 2;
+   b = (b & 0xAA) >> 1 | (b & 0x55) << 1;
+   return b;
+}

--- a/middleware/src/c_utils.c
+++ b/middleware/src/c_utils.c
@@ -13,9 +13,6 @@ void endian_swap(void *ptr, int size)
     }
 }
 
-/// @brief Reverses the bit order of a byte
-/// @param b byte
-/// @return the same byte but wuth the bits reversed
 unsigned char reverse_bits(unsigned char b) {
    b = (b & 0xF0) >> 4 | (b & 0x0F) << 4;
    b = (b & 0xCC) >> 2 | (b & 0x33) << 2;

--- a/middleware/src/c_utils.c
+++ b/middleware/src/c_utils.c
@@ -16,7 +16,7 @@ void endian_swap(void *ptr, int size)
 /// @brief Reverses the bit order of a byte
 /// @param b byte
 /// @return the same byte but wuth the bits reversed
-unsigned char reverse(unsigned char b) {
+unsigned char reverse_bits(unsigned char b) {
    b = (b & 0xF0) >> 4 | (b & 0x0F) << 4;
    b = (b & 0xCC) >> 2 | (b & 0x33) << 2;
    b = (b & 0xAA) >> 1 | (b & 0x55) << 1;


### PR DESCRIPTION
Reverses the bit order each bit addressable byte of the DTI yaml, as it is in the opposite order as is documented.

Turns out calypso always reads left to right, while for some reason the memcpy and can being sent spits out the bits right to left (per byte) probably as data is stored most to least significant bits.  Very confusing and probably a calypso way to fix it, however it is much easier if we standardize bits to be sent should be ordered 

Example: 
Fuse buffer created: `1(A) 1(B) 1101111(E) ` 
Fuse buffer sent over can `1(B) 1101111` `00000001(A) `

After this PR the buffer is the same, but by reversing each bit we get:
`1(A) 1(B) 110111` `1(E) 00000000`

If this makes sense to ppl I will make the followup MPU PR that reverses both fuse and shutdown buffer using the function included here (a stackoverflow copypasta).

The alternative, if this is too ugly or improper, is to find a way for calypso to identify a bitwise extraction (size<8) and call `reverse_bits` on it.