### PR TITLE
More yaml

### DIFF
--- a/cangen/can-messages/bms.yaml
+++ b/cangen/can-messages/bms.yaml
@@ -215,7 +215,7 @@ msgs:
         name: "BMS/Debug/Spare2"
         unit: ""
         size: 16
-     - !DiscreteField
+    - !DiscreteField
         name: "BMS/Debug/Spare3"
         unit: ""
         size: 32

--- a/cangen/can-messages/bms.yaml
+++ b/cangen/can-messages/bms.yaml
@@ -197,3 +197,25 @@ msgs:
         unit: "C"
         size: 8
         signed: true
+
+# debugging only - use messages as needed, be sure to fill rest with FFs and only send from one place in code
+- !CANMsg
+    id: "0x702"
+    desc: "BMS Debug"
+    fields:
+    - !DiscreteField
+        name: "BMS/Debug/Spare0"
+        unit: ""
+        size: 8
+    - !DiscreteField
+        name: "BMS/Debug/Spare1"
+        unit: ""
+        size: 8
+    - !DiscreteField
+        name: "BMS/Debug/Spare2"
+        unit: ""
+        size: 16
+     - !DiscreteField
+        name: "BMS/Debug/Spare3"
+        unit: ""
+        size: 32

--- a/cangen/can-messages/mpu.yaml
+++ b/cangen/can-messages/mpu.yaml
@@ -54,6 +54,28 @@ msgs:
         name: "MPU/Sense/Voltage"
         unit: "V"
         size: 32
+
+# debugging only - use messages as needed, be sure to fill rest with FFs and only send from one place in code
+- !CANMsg
+    id: "0x701"
+    desc: "MPU Debug"
+    fields:
+    - !DiscreteField
+        name: "MPU/Debug/Spare0"
+        unit: ""
+        size: 8
+    - !DiscreteField
+        name: "MPU/Debug/Spare1"
+        unit: ""
+        size: 8
+    - !DiscreteField
+        name: "MPU/Debug/Spare2"
+        unit: ""
+        size: 16
+     - !DiscreteField
+        name: "MPU/Debug/Spare3"
+        unit: ""
+        size: 32
         
 - !CANMsg
     id: "0x123"

--- a/cangen/can-messages/mpu.yaml
+++ b/cangen/can-messages/mpu.yaml
@@ -55,6 +55,32 @@ msgs:
         unit: "V"
         size: 32
 
+- !CANMsg
+    id: "0x504"
+    desc: "MPU Accel Pedals"
+    fields:
+    - !DiscreteField
+        name: "MPU/Pedals/Accelerator_1"
+        unit: ""
+        size: 32
+    - !DiscreteField
+        name: "MPU/Pedals/Accelerator_2"
+        unit: ""
+        size: 32
+
+- !CANMsg
+    id: "0x505"
+    desc: "MPU Brake Pedals"
+    fields:
+    - !DiscreteField
+        name: "MPU/Pedals/Brake_1"
+        unit: ""
+        size: 32
+    - !DiscreteField
+        name: "MPU/Pedals/Brake_2"
+        unit: ""
+        size: 32
+
 # debugging only - use messages as needed, be sure to fill rest with FFs and only send from one place in code
 - !CANMsg
     id: "0x701"

--- a/cangen/can-messages/mpu.yaml
+++ b/cangen/can-messages/mpu.yaml
@@ -72,7 +72,7 @@ msgs:
         name: "MPU/Debug/Spare2"
         unit: ""
         size: 16
-     - !DiscreteField
+    - !DiscreteField
         name: "MPU/Debug/Spare3"
         unit: ""
         size: 32


### PR DESCRIPTION
Adds more yaml including spare messages, to be accompanied with telmetry  fixes branch in MPU.

The purpose of spare messages is for BMS and MPU, if there is a problem that must be debugged on the fly, one can add that can message ID and fill in the whole message, and just read it how you wish without re-deploying calypso.  This will be helpful if needed at fsae, where nick probably will not have the ability to re-deploy calypso but may need to use telemetry sending.