### PR TITLE
Generic drivers

### DIFF
--- a/general/include/LTC4015.h
+++ b/general/include/LTC4015.h
@@ -10,8 +10,7 @@
 #define LTC4015_H_
 
 #include <stdint.h>
-#include "stm32f4xx_hal.h"
-#include "stm32f4xx_hal_i2c.h"
+#include "stm32xx_hal.h"
 
 //Device address 
 #define LTC4015_ADDR_68 (0x68) 

--- a/general/include/lsm6dso.h
+++ b/general/include/lsm6dso.h
@@ -9,8 +9,7 @@
 #ifndef LSM6DSO_H
 #define LSM6DSO_H
 #include <stdint.h>
-#include "stm32f4xx_hal.h"
-#include "stm32f4xx_hal_i2c.h"
+#include "stm32xx_hal.h"
 
 #define LSM6DSO_I2C_ADDRESS                 0x6A << 1   /* Shifted because datasheet said to */
 // Not sure if these are all needed, also not sure if more need to be added

--- a/general/include/ltc68041.h
+++ b/general/include/ltc68041.h
@@ -50,8 +50,7 @@ Copyright 2013 Linear Technology Corp. (LTC)
 #ifndef LTC68041_H
 #define LTC68041_H
 
-#include "stm32f4xx_hal.h"
-#include "stm32f4xx_hal_spi.h"
+#include "stm32xx_hal.h"
 
 #define LTC_MAX_RETRIES 10
 #define LTC_BAD_READ 0xFEEEEEEE

--- a/general/include/m24c32.h
+++ b/general/include/m24c32.h
@@ -3,8 +3,7 @@
 
 #include <stdint.h>
 #include <string.h>
-#include "stm32f4xx_hal.h"
-#include "stm32f4xx_hal_i2c.h"
+#include "stm32xx_hal.h"
 
 #define M24C32_I2C_ADDR     0x50
 #define M24C32_PAGE_SIZE    32

--- a/general/include/max7314.h
+++ b/general/include/max7314.h
@@ -3,8 +3,7 @@
 
 /* Drivers for MAX7314AEG+T */
 
-#include "stm32f4xx_hal.h"
-#include "stm32f4xx_hal_i2c.h"
+#include "stm32xx_hal.h"
 #include <stdbool.h>
 
 typedef enum {

--- a/general/include/pi4ioe.h
+++ b/general/include/pi4ioe.h
@@ -10,8 +10,7 @@
 #define PI4IOE_H
 
 #include <stdint.h>
-#include "stm32f4xx_hal.h"
-#include "stm32f4xx_hal_i2c.h"
+#include "stm32xx_hal.h"
 
 typedef struct
 {

--- a/general/include/sht30.h
+++ b/general/include/sht30.h
@@ -1,7 +1,7 @@
 #ifndef sht30_h
 #define sht30_h
 
-#include "stm32f4xx_hal.h"
+#include "stm32xx_hal.h"
 #include <stdint.h>
 #include <stdbool.h>
 

--- a/general/include/stm32xx_hal.h
+++ b/general/include/stm32xx_hal.h
@@ -1,0 +1,16 @@
+#ifndef STM32XX_HAL_H
+#define STM32XX_HAL_H
+
+#ifdef STM32F405xx
+#include "stm32f4xx_hal.h"
+#endif
+
+#ifdef STM32H745xx
+#include "stm32h7xx_hal.h"
+#endif
+
+#ifdef STM32G431xx
+#include "stm32g4xx_hal.h"
+#endif
+
+#endif /* STM32XX_HAL_H*/

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -5,8 +5,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include "stm32f4xx_hal.h"
-#include "stm32f4xx_hal_can.h"
+#include "stm32xx_hal.h"
 #include "c_utils.h"
 
 /*

--- a/platforms/stm32f405/include/stm32xx_hal.h
+++ b/platforms/stm32f405/include/stm32xx_hal.h
@@ -1,0 +1,16 @@
+#ifndef STM32XX_HAL_H
+#define STM32XX_HAL_H
+
+#ifdef STM32F405xx
+#include "stm32f4xx_hal.h"
+#endif
+
+#ifdef STM32H745xx
+#include "stm32h7xx_hal.h"
+#endif
+
+#ifdef STM32G431xx
+#include "stm32g4xx_hal.h"
+#endif
+
+#endif /* STM32XX_HAL_H*/

--- a/platforms/stm32g431/include/fdcan.h
+++ b/platforms/stm32g431/include/fdcan.h
@@ -5,8 +5,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include "stm32g4xx_hal.h"
-#include "stm32g4xx_hal_fdcan.h"
+#include "stm32xx_hal.h"
 
 /* function pointer type for the callback */
 typedef void (*can_callback_t)(FDCAN_HandleTypeDef *hcan);

--- a/platforms/stm32g431/include/stm32xx_hal.h
+++ b/platforms/stm32g431/include/stm32xx_hal.h
@@ -1,0 +1,16 @@
+#ifndef STM32XX_HAL_H
+#define STM32XX_HAL_H
+
+#ifdef STM32F405xx
+#include "stm32f4xx_hal.h"
+#endif
+
+#ifdef STM32H745xx
+#include "stm32h7xx_hal.h"
+#endif
+
+#ifdef STM32G431xx
+#include "stm32g4xx_hal.h"
+#endif
+
+#endif /* STM32XX_HAL_H*/


### PR DESCRIPTION
## Changes
Added in an ifdef that detects which STM platform we are building for to make the drivers somewhat agnostic to which STM they are running on. This is because the different peripherals in the STM we talk thru are standardized across the STM lineup and should not have to make essentially the exact same code to get a project to build except change the HAL include.

## Notes

Note that I had to add in this include into every include directory to make specifically the Charger firmware build, since it doesn't use any drivers. This can be easily fixed in the future by just putting all the drivers into one directory and eliminating the platforms directory OR moving everything under an `stm32` platform to set a precedent for using other types of chips, i.e. ESP32

## Test Cases

- Cerberus built
- Iroh built
- Shepherd BMS 2.0 built
- Proteus built

## To Do

_Any remaining things that need to get done_

not really other than the thing i said in the notes
