### PR TITLE
Rust synth encoding

### DIFF
--- a/cangen/CANField.py
+++ b/cangen/CANField.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Optional
 from dataclasses import dataclass
+import math
 
 @dataclass 
 class CANPoint:
@@ -13,6 +14,7 @@ class CANPoint:
     endianness : str = "big"
     final_type: str = "f32"
     format: Optional[str] = None
+    default: Optional[float] = 0
 
     def get_size_bytes(self):
         # Calculate max number of bytes to represent value
@@ -24,6 +26,9 @@ class CANPoint:
     
     def get_size_bits(self):
         return self.size
+    
+    def get_size_min_bytes(self):
+        return math.ceil(self.size / 8.0) * 8 
     
 @dataclass
 class NetField:

--- a/cangen/CANMsg.py
+++ b/cangen/CANMsg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import Optional
 from .CANField import NetField
 
 @dataclass
@@ -11,5 +12,19 @@ class CANMsg:
     desc: str   # Brief name of CAN message, used for generating function names
     fields: list[NetField] # List of CAN fields in the message
 
-    def __setstate__(self, state):
-        self.__init__(**state)
+@dataclass
+class EncodableCANMsg(CANMsg):
+    '''
+    Represents a CAN message that can also be encoded to using the command_data protobuf spec.
+    Has all properties of a decodable message, but also has a key and optional is_ext field.
+
+    IMPORTANT: Use the default flag in each CANPoint to specify a default value to be sent before a command is sent.
+    '''
+    '''
+    The name to be used to look up command data over mqtt
+    '''
+    key: str
+    '''
+    Whether the CAN ID is extended or standard
+    '''
+    is_ext: Optional[bool] = False

--- a/cangen/README.md
+++ b/cangen/README.md
@@ -11,8 +11,8 @@ Messages should follow these rules:
 3. Wherever possible, bit-wise decoding and byte-wise decoding should happen in seperate bytes to avoid confusion.
 Ex. If there are 5 messages of size one (booleans), add a 3 bit filler before adding a 16 bit number
 4. Message totals should be byte aligned, meaning total bit size of a message should be a power of 2
-5. **Signed messages must be 8,16,or 32 bits!**
-6. **Little endian messages must be 8,16, or 32 bits!**
+5. **Signed messages must be 8,16,or 32 bits and byte aligned!**
+6. **Little endian messages must be 8,16, or 32 bits and byte aligned!**
 7. Maximum size of a sent message (default, aka send=True), is 32 bits
 8. Unsent messages should only contain the size parameter
 9. Make the topic of an EncodableCANMsg be "Calypso/Bidir/State/{key}/{field_name}"

--- a/cangen/README.md
+++ b/cangen/README.md
@@ -14,6 +14,9 @@ Ex. If there are 5 messages of size one (booleans), add a 3 bit filler before ad
 5. **Signed messages must be 8,16,or 32 bits!**
 6. **Little endian messages must be 8,16, or 32 bits!**
 7. Maximum size of a sent message (default, aka send=True), is 32 bits
+8. Unsent messages should only contain the size parameter
+9. Make the topic of an EncodableCANMsg be "Calypso/Bidir/State/{key}/{field_name}"
+10. The description field must be only letters and spaces, upper or lowercase
 
 Message guide:
 1. Use previous examples for most things
@@ -22,7 +25,10 @@ Message guide:
 Note: Single bit messages are memcpy-ed wrong by default, you may need to use `reverse_bits` in `c_utils.h`
 Note: Please use big endian whenever possible, as that is the standard at which our MC, Charger Box, etc. expect it.  Use `endian_swap` in `c_utils.h`
 
-YAML info.
+## YAML Spec.
+
+### Decodable messages 
+
 ```
 # all files start with this yaml
 !Messages
@@ -42,7 +48,22 @@ msgs:
             signed: false # (optional) whether the number is in signed twos complement form, default is false
             endianness: "big" # (optional) the byte endianness of the bits being read, "big" or "false", "big" is default
             format: "formatter_name" # (optional) the name of the formatter to use, default is no formatting, see above for formatter info
-            final_type: "f32" # (optional, not recommended) the final type of the data            
+            final_type: "f32" # (optional, not recommended) the final type of the data           
+
+```
+
+### Encodable messages
+Occassionally you may want Calypso to also send a message on the CAN network.  Use the above fields, with these modifications/additions:
+It is recommended that the decoding of the message be done to the topic "Calypso/Bidir/State/{key}/{field_name}".  Note decoding works exactly the same with these messages, so serves as an accurate representation of what Calypso is current sending out to the car.
+
+```
+- !EncodableCANMsg # use this instead of CANMsg
+    is_ext: false # (optional) whether the CAN ID of the message is extended or standard, default is false
+    key: # the key to index the encodable message to, so it would be sent to Calypso on "Calypso/Bidir/Command/{key}"
+
+
+        - !CANPoint:
+            default: 0 # (optional) the default value to be sent before a command is recieved or when an empty command is recieved, default is 0.  This is ignored when decoding the point
 ```
 
 ### Directory Structure
@@ -57,11 +78,6 @@ msgs:
 |
 |───Messages.py:
 |   └───Messages        # Container for all messages related to a node
-|
-|───Decoding.py:
-|   |───LittleEndian
-|   |───BigEndian
-|   └───TwosComplement
 |
 |───YAMLParser.py:
 |   └───YAMLParser      # Parses a YAML file into CAN message structures

--- a/cangen/Result.py
+++ b/cangen/Result.py
@@ -6,8 +6,14 @@ class Result:
    master_mapping is the synthesized Rust code for the master_mapping.rs file.
    """
    decode_data: str
-   master_mapping: str
+   decode_master_mapping: str
+   encode_data: str
+   encode_master_mapping: str
+   format_data: str
 
-   def __init__(self, decode_data: str, master_mapping: str):
+   def __init__(self, decode_data: str, master_mapping: str, encode_data: str, encode_master_mapping: str, format_data: str):
       self.decode_data = decode_data
-      self.master_mapping = master_mapping
+      self.decode_master_mapping = master_mapping
+      self.encode_data = encode_data
+      self.encode_master_mapping = encode_master_mapping
+      self.format_data = format_data

--- a/cangen/RustSynth.py
+++ b/cangen/RustSynth.py
@@ -167,7 +167,7 @@ class RustSynth:
 		"""
 		Parse can point to do conversions on it, and maybe wrap in formatter
 		"""
-		return f"	{self.parse_encoders(field, index)};\n"
+		return f"	{self.parse_encoders(field, index)};"
 
 	def function_name_decode(self, desc: str) -> str:
 		"""
@@ -248,7 +248,7 @@ class RustSynth:
 		encoders to the data and casting the result to the final type of the CANUnit.
 		"""
 
-		default_statement = f"&({field.default} as f32)"
+		default_statement = f"&({field.default}_f32)"
 		float_final = self.format_data(field, f"*data.get({index}).unwrap_or({default_statement})")
 		
 		if field.endianness == "big":
@@ -292,11 +292,11 @@ class RustSynth:
 
 	def encode_data_inst(self, msg: EncodableCANMsg) -> str:
 		return f"""
-	return EncodeData {{
+	EncodeData {{
 		value: writer.into_writer(),
 		id: {int(msg.id, 16)},   // {msg.id}
 		is_ext: {str(msg.is_ext).lower()},
-	}};"""
+	}}"""
 
 
 class RustSnippets:
@@ -373,11 +373,11 @@ pub fn decode_mock(_data: &[u8]) -> Vec::<DecodeData> {
 pub fn encode_mock(data: Vec<f32>) -> EncodeData {
     let mut writer = BitWriter::endian(Vec::new(), BigEndian);
     writer.write_from::<u8>(data.len() as u8).unwrap();
-    return EncodeData {
+    EncodeData {
         value: writer.into_writer(),
         id: 2047, // 0x7FF
         is_ext: false,
-    };
+    }
 }\n"""  # A debug decode function that is used for messages that don't have a decode function
 
 	network_encoding_start: str = "result.push(DecodeData::new(vec!["

--- a/cangen/RustSynth.py
+++ b/cangen/RustSynth.py
@@ -1,5 +1,5 @@
 from cangen.CANField import CANPoint
-from cangen.CANMsg import CANMsg
+from cangen.CANMsg import CANMsg, EncodableCANMsg
 from cangen.Result import Result
 from typing import List, Optional
 
@@ -14,42 +14,69 @@ class RustSynth:
 		returns a Result object that contains the synthesized Rust code for the
 		decode_data.rs and master_mapping.rs files
 		"""
-		result = Result("", "")
+		result = Result("", "", "", "", "")
 		result.decode_data += RustSnippets.ignore_clippy
-		result.decode_data += RustSnippets.format_impl
 		result.decode_data += RustSnippets.decode_data_import
 		result.decode_data += RustSnippets.decode_mock
 
-		result.master_mapping += RustSnippets.master_mapping_import
-		result.master_mapping += RustSnippets.message_info
-		result.master_mapping += RustSnippets.master_mapping_signature
+		result.encode_data += RustSnippets.ignore_clippy
+		result.encode_data += RustSnippets.encode_data_import
+		result.encode_data += RustSnippets.encode_mock
 
+		result.decode_master_mapping += RustSnippets.decode_master_mapping_import
+		result.decode_master_mapping += RustSnippets.decode_message_info
+		result.decode_master_mapping += RustSnippets.decode_master_mapping_signature
+
+		result.encode_master_mapping += RustSnippets.encode_master_mapping_import
+		result.encode_master_mapping += RustSnippets.encode_message_info
+		result.encode_master_mapping += RustSnippets.encode_master_mapping_signature
+
+		list_of_keys = []
 		for msg in msgs:
-			result.decode_data += self.synthesize(msg) + "\n"
-			result.master_mapping += self.map_msg_to_decoder(msg)
+			result.decode_data += self.synthesize_decode(msg) + "\n"
+			result.decode_master_mapping += self.map_msg_to_decoder(msg)
 
-		result.master_mapping += RustSnippets.master_mapping_closing
+			if (isinstance(msg, EncodableCANMsg)):
+				list_of_keys.append(msg.key)
+				result.encode_data += self.synthesize_encode(msg) + "\n"
+				result.encode_master_mapping += self.map_msg_to_encoder(msg)
+
+
+		result.encode_master_mapping += RustSnippets.encode_master_mapping_closing
+		result.encode_master_mapping += self.create_encode_key(list_of_keys)
+
+		result.decode_master_mapping += RustSnippets.decode_master_mapping_closing
+
+		result.format_data = RustSnippets.format_impl
+
+
 		return result
 
 	def map_msg_to_decoder(self, msg: CANMsg) -> str:
 		"""
 		Helper function that maps a given CANMsg to its decode function
 		"""
-		return f"    {msg.id} => MessageInfo::new({self.function_name(msg.desc)}),\n"
+		return f"    {msg.id} => DecodeMessageInfo::new({self.function_name_decode(msg.desc)}),\n"
+	
+	def map_msg_to_encoder(self, msg: EncodableCANMsg) -> str:
+		"""
+		Helper function that maps a given EncodableCANMsg to its encode function
+		"""
+		return f"    \"{msg.key}\" => EncodeMessageInfo::new({self.function_name_encode(msg.desc)}),\n"
 
-	def synthesize(self, msg: CANMsg) -> str:
+	def synthesize_decode(self, msg: CANMsg) -> str:
 		"""
 		Helper function that synthesizes the decode function for a given CANMsg
 		"""
 
 		# Generate Function Signature
-		signature: str = self.signature(msg.desc)
+		signature: str = self.signature_decode(msg.desc)
 
 		length_check: str = self.add_length_check(point for field in msg.fields for point in field.points)
 
 		# Generate a line for each field in the message
 		generated_lines: list[str] = []
-		generated_lines += self.parse_msg(msg)
+		generated_lines += self.parse_msg_decode(msg)
 
 		# Combine everything into one string
 		total_list: list[str] = (
@@ -58,8 +85,30 @@ class RustSynth:
 			+ [RustSnippets.decode_close]
 		)
 		return "\n".join(total_list)
+	
+	def synthesize_encode(self, msg: EncodableCANMsg) -> str:
+		"""
+		Helper function that synthesizes the encode function for a given EncodableCANMsg
+		"""
 
-	def parse_msg(self, msg: CANMsg) -> list[str]:
+		# Generate Function Signature
+		signature: str = self.signature_encode(msg.desc)
+
+		# Generate a line for each field in the message
+		generated_lines: list[str] = []
+		generated_lines += self.parse_msg_encode(msg)
+
+		ret_encode_inst = self.encode_data_inst(msg)
+
+		# Combine everything into one string
+		total_list: list[str] = (
+			[signature, RustSnippets.bitwriter_create]
+			+ generated_lines
+			+ [ret_encode_inst] + ["}"]
+		)
+		return "\n".join(total_list)
+
+	def parse_msg_decode(self, msg: CANMsg) -> list[str]:
 		result = []
 
 		# For all the fields in the CAN message, generate the required code
@@ -88,6 +137,16 @@ class RustSynth:
 					# if it is the last point, we can just exit out and save the resources of decoding it
 					result.append(f"            {','.join(self.decode_field_value(point, skip=True) for point in field.points)};")
 
+		return result
+	
+	def parse_msg_encode(self, msg: EncodableCANMsg) -> list[str]:
+		result = []
+		# flatten list to get points
+		pts_ls: CANPoint = [pt for field in msg.fields for pt in field.points]
+		# For all the points in the CAN message, generate the required code
+		for index, pt in enumerate(pts_ls, start=0):
+				result.append(self.encode_field_value(pt, index))
+
 
 		return result
 
@@ -104,19 +163,39 @@ class RustSynth:
 		"""
 		return f"{self.format_data(field, self.parse_decoders(field, skip))}"
 
-	def function_name(self, desc: str) -> str:
+	def encode_field_value(self, field: CANPoint, index: int) -> str:
+		"""
+		Parse can point to do conversions on it, and maybe wrap in formatter
+		"""
+		return f"	{self.parse_encoders(field, index)};\n"
+
+	def function_name_decode(self, desc: str) -> str:
 		"""
 		Helper function that generates the name of a decode function for a
 		given CANMsg based off the can message description
 		"""
 		return f"decode_{desc.replace(' ', '_').lower()}"
 
-	def signature(self, desc: str) -> str:
+	def function_name_encode(self, desc: str) -> str:
+		"""
+		Helper function that generates the name of a decode function for a
+		given CANMsg based off the can message description
+		"""
+		return f"encode_{desc.replace(' ', '_').lower()}"
+
+	def signature_decode(self, desc: str) -> str:
 		"""
 		Helper function that generates the signature of a decode function for a
 		given CANMsg based off the can message description
 		"""
-		return f"pub fn {self.function_name(desc)}(data: &[u8]) -> {RustSnippets.decode_return_type} {{"
+		return f"pub fn {self.function_name_decode(desc)}(data: &[u8]) -> {RustSnippets.decode_return_type} {{"
+	
+	def signature_encode(self, desc: str) -> str:
+		"""
+		Helper function that generates the signature of a decode function for a
+		given CANMsg based off the can message description
+		"""
+		return f"pub fn {self.function_name_encode(desc)}(data: Vec<f32>) -> {RustSnippets.encode_return_type} {{"
 
 	def finalize_line(self, topic: str, unit: str, val: str, topic_appends_name: Optional[str] = None ) -> str:
 		"""
@@ -149,6 +228,9 @@ class RustSynth:
 			else:
 				base = f"reader.read::<u32>({field.size}).unwrap()"
 		elif field.endianness == "little":
+			if (field.size != field.get_size_min_bytes()):
+				print("You cannot have a non byte sized signed number!")
+				exit(1)
 			# use the read_as_to, which requires byte sized data to get the correct sign bit
 			if field.signed:
 				base = f"reader.read_as_to::<LittleEndian, i{field.size}>().unwrap()"
@@ -158,9 +240,37 @@ class RustSynth:
 			print("Invalid endianness: ", field.endianness)
 			exit(1)
 
-			
-
 		return f"{base} as {field.final_type}"
+
+	def parse_encoders(self, field: CANPoint, index: int) -> str:
+		"""
+		Helper function that parses the encoders for a given CANUnit by applying the
+		encoders to the data and casting the result to the final type of the CANUnit.
+		"""
+
+		default_statement = f"&({field.default} as f32)"
+		float_final = self.format_data(field, f"*data.get({index}).unwrap_or({default_statement})")
+		
+		if field.endianness == "big":
+			if field.signed:
+				# doesnt need exact sign bit as it is in big endian form, the form of the native stream
+				base = f"writer.write_signed::<i{field.get_size_min_bytes()}>({field.size}, {float_final} as i{field.get_size_min_bytes()}).unwrap()"
+			else:
+				base = f"writer.write::<u{field.get_size_min_bytes()}>({field.size}, {float_final} as u{field.get_size_min_bytes()}).unwrap()"
+		elif field.endianness == "little":
+			if (field.size != field.get_size_min_bytes()):
+				print("You cannot have a non byte sized signed number!")
+				exit(1)
+
+			if field.signed:
+				base = f"writer.write_as_from::<LittleEndian, i{field.size}>({float_final} as i{field.size}).unwrap()"
+			else:
+				base = f"writer.write_as_from::<LittleEndian, u{field.size}>({float_final} as u{field.size}).unwrap()"
+		else:
+			print("Invalid endianness: ", field.endianness)
+			exit(1)
+
+		return base
 
 	def format_data(self, field: CANPoint, decoded_data: str) -> str:
 		"""
@@ -171,6 +281,22 @@ class RustSynth:
 		if field.format:
 			cf = f"FormatData::{field.format}({decoded_data})"
 		return cf
+
+	def create_encode_key(self, list_of_keys) -> str:
+		lr = f"pub const ENCODABLE_KEY_LIST: [&str; {len(list_of_keys)}] = [\n"
+		for k in list_of_keys:
+			lr += f"\"{k}\",\n"
+		lr += "];\n"
+
+		return lr
+
+	def encode_data_inst(self, msg: EncodableCANMsg) -> str:
+		return f"""
+	return EncodeData {{
+		value: writer.into_writer(),
+		id: {int(msg.id, 16)},   // {msg.id}
+		is_ext: {str(msg.is_ext).lower()},
+	}};"""
 
 
 class RustSnippets:
@@ -208,56 +334,104 @@ impl FormatData {
 }"""
 
 	bitreader_create = "    let mut reader = BitReader::endian(Cursor::new(&data), BigEndian);"
+	bitwriter_create = "    let mut writer = BitWriter::endian(Vec::new(), BigEndian);"
 
 	decode_data_import: str = (
-		"""use super::data::Data;
+		"""
+		use crate::format_data::FormatData;
+		use super::data::DecodeData;
 			use std::io::Cursor;
 			use bitstream_io::{BigEndian, LittleEndian, BitReader, BitRead};\n
 		  """  # Importing the Data struct and the bistream io libraries
 	)
+	encode_data_import: str = (
+		"""
+		use crate::format_data::FormatData;
+		use super::data::EncodeData;
+			use bitstream_io::{BigEndian, LittleEndian, BitWriter, BitWrite};\n
+		  """  # Importing the Data struct and the bistream io libraries
+	)
 
-	decode_return_type: str = "Vec::<Data>"  # The return type of any decode function
+	decode_return_type: str = "Vec::<DecodeData>"  # The return type of any decode function
+	encode_return_type: str = "EncodeData"  # The return type of any decode function
 	decode_return_value: str = (
-		f"    let mut result: Vec<Data> = Vec::new();"  # Initializing the result vector
+		f"    let mut result: Vec<DecodeData> = Vec::new();"  # Initializing the result vector
 	)
 	decode_close: str = (
 		"	result\n}\n"  # Returning the result vector and closing the function
 	)
 
 	decode_mock: str = """
-pub fn decode_mock(_data: &[u8]) -> Vec::<Data> {
+pub fn decode_mock(_data: &[u8]) -> Vec::<DecodeData> {
 	let result = vec![
-	Data::new(vec![0.0], "Calypso/Unknown", "")
+	DecodeData::new(vec![0.0], "Calypso/Unknown", "")
 	];
 	result
 }\n"""  # A debug decode function that is used for messages that don't have a decode function
 
-	network_encoding_start: str = "result.push(Data::new(vec!["
+	encode_mock: str = """
+pub fn encode_mock(data: Vec<f32>) -> EncodeData {
+    let mut writer = BitWriter::endian(Vec::new(), BigEndian);
+    writer.write_from::<u8>(data.len() as u8).unwrap();
+    return EncodeData {
+        value: writer.into_writer(),
+        id: 2047, // 0x7FF
+        is_ext: false,
+    };
+}\n"""  # A debug decode function that is used for messages that don't have a decode function
+
+	network_encoding_start: str = "result.push(DecodeData::new(vec!["
 	network_encoding_closing: str = ");"
 
-	master_mapping_import: str = (
-		"use super::decode_data::*;\nuse super::data::Data;\n"  # Importing all the functions in decode_data.rs file and the Data struct
+	decode_master_mapping_import: str = (
+		"use super::decode_data::*;\nuse super::data::DecodeData;\n"  # Importing all the functions in decode_data.rs file and the Data struct
 	)
 
-	master_mapping_signature: str = (
-		"pub fn get_message_info(id: &u32) -> MessageInfo {\n   match id {"  # The signature of the master_mapping function
+	encode_master_mapping_import: str = (
+		"use super::encode_data::*;\nuse super::data::EncodeData;\n"  # Importing all the functions in encode_data.rs file and the Data struct
 	)
 
-	master_mapping_closing: str = (
-		"    _ => MessageInfo::new(decode_mock),\n    }\n}"  # The closing of the master_mapping function and the default case for the match statement that returns the mock decode function
+	decode_master_mapping_signature: str = (
+		"pub fn get_message_info(id: &u32) -> DecodeMessageInfo {\n   match id {"  # The signature of the master_mapping function
 	)
 
-	message_info = """
-	pub struct MessageInfo {
-		pub decoder: fn(data: &[u8]) -> Vec<Data>,
+	encode_master_mapping_signature: str = (
+		"pub fn get_message_info(key: String) -> EncodeMessageInfo {\n   let key_owned = key.as_str();\n	match key_owned {"  
+		# The signature of the master_mapping function
+	)
+
+	decode_master_mapping_closing: str = (
+		"    _ => DecodeMessageInfo::new(decode_mock),\n    }\n}\n"  # The closing of the master_mapping function and the default case for the match statement that returns the mock decode function
+	)
+
+	encode_master_mapping_closing: str = (
+		"    _ => EncodeMessageInfo::new(encode_mock),\n    }\n}\n"  # The closing of the master_mapping function and the default case for the match statement that returns the mock encode function
+	)
+
+
+	decode_message_info = """
+	pub struct DecodeMessageInfo {
+		pub decoder: fn(data: &[u8]) -> Vec<DecodeData>,
 	}
 
-	impl MessageInfo {
-		pub fn new(decoder: fn(data: &[u8]) -> Vec<Data>) -> Self {
+	impl DecodeMessageInfo {
+		pub fn new(decoder: fn(data: &[u8]) -> Vec<DecodeData>) -> Self {
 			Self {
 				decoder
 			}
 		}
+	}
+	""" # The MessageInfo struct that is used to store the decode function for a given message
+
+	encode_message_info = """
+	pub struct EncodeMessageInfo {
+    	pub encoder: fn(data: Vec<f32>) -> EncodeData,
+	}
+
+	impl EncodeMessageInfo {
+    	pub fn new(encoder: fn(data: Vec<f32>) -> EncodeData) -> Self {
+        	Self { encoder }
+    	}
 	}
 	""" # The MessageInfo struct that is used to store the decode function for a given message
 

--- a/cangen/YAMLParser.py
+++ b/cangen/YAMLParser.py
@@ -1,5 +1,5 @@
 from ruamel.yaml import YAML
-from cangen.CANMsg import CANMsg
+from cangen.CANMsg import CANMsg, EncodableCANMsg
 from cangen.CANField import CANPoint, NetField
 from cangen.Format import Format
 from cangen.Messages import Messages
@@ -16,6 +16,7 @@ class YAMLParser:
         self.yaml = YAML(typ="safe")
         self.yaml.register_class(Messages)
         self.yaml.register_class(CANMsg)
+        self.yaml.register_class(EncodableCANMsg)
         self.yaml.register_class(NetField)
         self.yaml.register_class(CANPoint)
 

--- a/cangen/can-messages/calypso_cmd.yaml
+++ b/cangen/can-messages/calypso_cmd.yaml
@@ -11,17 +11,16 @@ msgs:
         unit: "Z"
         points:
         - !CANPoint
-            size: 16
-            endianness: "little"
+            size: 32
+            endianness: "big"
             format: "divide10000"
-            default: 69.55
+            default: 18.443
     - !NetField
         name: "Calypso/Bidir/State/FirstOff/B"
         unit: "G"
         points:
         - !CANPoint
-            size: 16
-            endianness: "big"
+            size: 8
             signed: true
             default: 35.4
     - !NetField
@@ -29,7 +28,7 @@ msgs:
         unit: "G"
         points:
         - !CANPoint
-            size: 16
+            size: 8
             endianness: "big"
             default: 19
     - !NetField
@@ -39,6 +38,7 @@ msgs:
         - !CANPoint
             size: 16
             endianness: "little"
+            format: "divide100"
             signed: true
             default: -21.8
 

--- a/cangen/can-messages/calypso_cmd.yaml
+++ b/cangen/can-messages/calypso_cmd.yaml
@@ -1,0 +1,69 @@
+!Messages
+msgs:
+
+- !EncodableCANMsg
+  id: "0x450"
+  desc: "Example Enc Msg"
+  key: "FirstOff"
+  fields:
+    - !NetField
+        name: "Calypso/Bidir/State/FirstOff/A"
+        unit: "Z"
+        points:
+        - !CANPoint
+            size: 16
+            endianness: "little"
+            format: "divide10000"
+            default: 69.55
+    - !NetField
+        name: "Calypso/Bidir/State/FirstOff/B"
+        unit: "G"
+        points:
+        - !CANPoint
+            size: 16
+            endianness: "big"
+            signed: true
+            default: 35.4
+    - !NetField
+        name: "Calypso/Bidir/State/FirstOff/C"
+        unit: "G"
+        points:
+        - !CANPoint
+            size: 16
+            endianness: "big"
+            default: 19
+    - !NetField
+        name: "Calypso/Bidir/State/FirstOff/D"
+        unit: "G"
+        points:
+        - !CANPoint
+            size: 16
+            endianness: "little"
+            signed: true
+            default: -21.8
+
+- !EncodableCANMsg
+  id: "0xFFFFF"
+  desc: "Example Enc Msg Ext"
+  key: "SecondOff"
+  is_ext: true
+  fields:
+    - !NetField
+        name: "Calypso/Bidir/State/SecondOff/A"
+        unit: "GG"
+        points:
+        - !CANPoint
+            size: 32
+            endianness: "little"
+            default: 0
+
+- !CANMsg
+  id: "0x7FF"
+  desc: "Calypso bidir unknown key"
+  fields:
+    - !NetField
+        name: "Calypso/Bidir/Unknown"
+        unit: "pts" # this is the count of points in the unknown message, for debugging
+        points:
+        - !CANPoint
+          size: 8

--- a/cangen/can-messages/dti.yaml
+++ b/cangen/can-messages/dti.yaml
@@ -316,7 +316,7 @@ msgs:
     desc: "Brake_Current_Command"
     fields:
     - !NetField
-        name: "DTI/Commands/Brake_Current_Target"
+        name: "MPU/Commands/Brake_Current_Target"
         unit: "A"
         points:
         - !CANPoint

--- a/cangen/can-messages/dti.yaml
+++ b/cangen/can-messages/dti.yaml
@@ -316,7 +316,7 @@ msgs:
     desc: "Brake_Current_Command"
     fields:
     - !NetField
-        name: "MPU/Commands/Brake_Current_Target"
+        name: "DTI/Commands/Brake_Current_Target"
         unit: "A"
         points:
         - !CANPoint

--- a/cangen/can-messages/mpu.yaml
+++ b/cangen/can-messages/mpu.yaml
@@ -33,18 +33,58 @@ msgs:
         
 - !CANMsg
     id: "0x500"
-    desc: "MPU Acceleromter"
+    desc: "MPU Sense Acceleromter"
     fields:
     - !NetField   # X, Y, and Z should be decoded together
-        name: "MPU/Accel"
+        name: "MPU/Sense/Accel"
         unit: "g"
         points:
         - !CANPoint
             size: 16
         - !CANPoint
-            size: 8
+            size: 16
         - !CANPoint
             size: 16
+
+- !CANMsg
+    id: "0x506"
+    desc: "MPU Sense Gyro"
+    fields:
+    - !NetField   # X, Y, and Z should be decoded together
+        name: "MPU/Sense/Gyro"
+        unit: ""
+        points:
+        - !CANPoint
+            size: 16
+        - !CANPoint
+            size: 16
+        - !CANPoint
+            size: 16
+
+- !CANMsg
+    id: "0x507"
+    desc: "MPU Sense Temp"
+    fields:
+    - !NetField
+        name: "MPU/Sense/Temp_IMU"
+        unit: "C"
+        points:
+        - !CANPoint
+            size: 16
+            signed: true
+    # - !NetField
+    #     name: "MPU/Sense/Temp_SHT"
+    #     unit: "C"
+    #     points:
+    #     - !CANPoint
+    #         size: 16
+    #         signed: tre
+    # - !NetField
+    #     name: "MPU/Sense/Humidity_SHT"
+    #     unit: ""
+    #     points:
+    #     - !CANPoint
+    #         size: 16
 
 
 - !CANMsg
@@ -66,7 +106,7 @@ msgs:
 
 - !CANMsg
     id: "0x503"
-    desc: "MPU Sense"
+    desc: "MPU Sense Voltage"
     fields:
     - !NetField
         name: "MPU/Sense/Voltage"

--- a/cangen/can-messages/mpu.yaml
+++ b/cangen/can-messages/mpu.yaml
@@ -30,61 +30,21 @@ msgs:
         - !CANPoint
             size: 8
         
-
+        
 - !CANMsg
     id: "0x500"
-    desc: "MPU Sense Acceleromter"
+    desc: "MPU Acceleromter"
     fields:
     - !NetField   # X, Y, and Z should be decoded together
-        name: "MPU/Sense/Accel"
+        name: "MPU/Accel"
         unit: "g"
         points:
         - !CANPoint
             size: 16
         - !CANPoint
-            size: 16
+            size: 8
         - !CANPoint
             size: 16
-
-- !CANMsg
-    id: "0x506"
-    desc: "MPU Sense Gyro"
-    fields:
-    - !NetField   # X, Y, and Z should be decoded together
-        name: "MPU/Sense/Gyro"
-        unit: ""
-        points:
-        - !CANPoint
-            size: 16
-        - !CANPoint
-            size: 16
-        - !CANPoint
-            size: 16
-
-- !CANMsg
-    id: "0x507"
-    desc: "MPU Sense Temp"
-    fields:
-    - !NetField
-        name: "MPU/Sense/Temp_IMU"
-        unit: "C"
-        points:
-        - !CANPoint
-            size: 16
-            signed: true
-    # - !NetField
-    #     name: "MPU/Sense/Temp_SHT"
-    #     unit: "C"
-    #     points:
-    #     - !CANPoint
-    #         size: 16
-    #         signed: tre
-    # - !NetField
-    #     name: "MPU/Sense/Humidity_SHT"
-    #     unit: ""
-    #     points:
-    #     - !CANPoint
-    #         size: 16
 
 
 - !CANMsg
@@ -106,7 +66,7 @@ msgs:
 
 - !CANMsg
     id: "0x503"
-    desc: "MPU Sense Voltage"
+    desc: "MPU Sense"
     fields:
     - !NetField
         name: "MPU/Sense/Voltage"


### PR DESCRIPTION
Add bidirectionality to calypso.

Replicates most functionaly of decoding with slight tweaks here and there, otherwise somewhat duplication of decoding with just changing class names and whatnot,