### PR TITLE
Added LV Sense SOC to cerb CAN spec

### DIFF
--- a/cangen/can-messages/mpu.json
+++ b/cangen/can-messages/mpu.json
@@ -373,6 +373,22 @@
             "format": "divide10000"
           }
         ]
+      },
+      {
+        "name": "MPU/Sense/SOC",
+        "unit": "%",
+        "sim": {
+          "min": 5,
+          "max": 99,
+          "inc_min": 0.1,
+          "inc_max": 0.5
+        },
+        "points": [
+          {
+            "size": 32,
+            "endianness": "little"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Changes

- Added LV Sense SOC to `mpu.json` (See https://github.com/Northeastern-Electric-Racing/Cerberus/issues/219)

Closes https://github.com/Northeastern-Electric-Racing/Cerberus/issues/219
