### PR TITLE
Added support to decode IEEE754 32-bit floats over CAN

### DIFF
--- a/cangen/README.md
+++ b/cangen/README.md
@@ -107,9 +107,9 @@ Within the `points` member of a NetField object, there is a list of Point object
 - `size`, an integer representing the size to be read in bits
 - `signed` (optional), boolean representing whether or not the number is signed in two's complement form (`false` by default) 
 - `endianness` (optional), string representing the byte endianness of the bits being read, either `"big"` or `"little"` (`"big"` by default)
-- `format` (optional, not recommended), string representing the final type of the data (`"f32"` by default)
+- `format` (optional), string representing the format of the bits (e.g. `divide100`) (blank by default)
 - `default_value` (optional, only for Encodable Messages), float representing the default value to be sent before a command is received or when an empty command is received. This is ignored when decoding the Point (`0` by default) 
-- `ieee754_f32` (optional), boolean indicating if the bits in the Point should be interpreted as an IEEE754 32-bit float (`false` by default)
+- `ieee754_f32` (optional), boolean indicating if the bits in the Point should be interpreted as an IEEE754 32-bit float. **Be sure to endian swap the float before sending!!** (`false` by default)
 
 #### Sim
 Within the `sim` member of a NetField object, there is a single sim object.  This object is one of two types, either `sweep` or `enum`.  However these types are implied, not written in the JSON, just use them correctly!

--- a/cangen/README.md
+++ b/cangen/README.md
@@ -109,6 +109,7 @@ Within the `points` member of a NetField object, there is a list of Point object
 - `endianness` (optional), string representing the byte endianness of the bits being read, either `"big"` or `"little"` (`"big"` by default)
 - `format` (optional, not recommended), string representing the final type of the data (`"f32"` by default)
 - `default_value` (optional, only for Encodable Messages), float representing the default value to be sent before a command is received or when an empty command is received. This is ignored when decoding the Point (`0` by default) 
+- `ieee754_f32` (optional), boolean indicating if the bits in the Point should be interpreted as an IEEE754 32-bit float (`false` by default)
 
 #### Sim
 Within the `sim` member of a NetField object, there is a single sim object.  This object is one of two types, either `sweep` or `enum`.  However these types are implied, not written in the JSON, just use them correctly!

--- a/cangen/can-messages/bms.json
+++ b/cangen/can-messages/bms.json
@@ -987,7 +987,8 @@
                 "unit": "",
                 "points": [
                     {
-                        "size": 32
+                        "size": 32,
+                        "ieee754_f32": true
                     }
                 ]
             }

--- a/cangen/can-messages/bms.json
+++ b/cangen/can-messages/bms.json
@@ -987,8 +987,7 @@
                 "unit": "",
                 "points": [
                     {
-                        "size": 32,
-                        "ieee754_f32": true
+                        "size": 32
                     }
                 ]
             }


### PR DESCRIPTION
## Changes

- Calypso can now read the bits of a CANPoint as an IEEE754 32-bit float (see https://github.com/Northeastern-Electric-Racing/Calypso/issues/75).
- To accommodate this, a new field has been added to the CAN spec. ieee754_f32 is an optional boolean field in the CANPoint spec, which indicates that the CANPoint should be decoded as an f32.
- `BMS/Debug/Spare3` is now an IEEE754 32-bit float, for testing.

## Notes

- CANPoints that wish to use this feature must specify the `ieee754_f32` field as `true` in the JSON.

Closes [Calypso #75](https://github.com/Northeastern-Electric-Racing/Calypso/issues/75)
