### PR TITLE
Fixes PCA driver

### DIFF
--- a/general/include/pca9539.h
+++ b/general/include/pca9539.h
@@ -39,19 +39,19 @@ PCA 9539 16 bit GPIO expander.  Datasheet: https://www.ti.com/lit/ds/symlink/pca
  * @brief Pointer to write function
  * 
  */
-typedef uint8_t (*WritePtr)(uint16_t dev_addr, uint8_t reg, uint8_t *data,
-			    uint8_t size);
+typedef uint8_t (*PCA_Write)(uint16_t dev_addr, uint8_t reg, uint8_t *data,
+			     uint8_t size);
 
 /**
  * @brief Pointer to read function
  * 
  */
-typedef uint8_t (*ReadPtr)(uint16_t dev_addr, uint8_t reg, uint8_t *data,
-			   uint8_t size);
+typedef uint8_t (*PCA_Read)(uint16_t dev_addr, uint8_t reg, uint8_t *data,
+			    uint8_t size);
 
 typedef struct {
-	WritePtr write;
-	ReadPtr read;
+	PCA_Write write;
+	PCA_Read read;
 
 	uint16_t dev_addr;
 } pca9539_t;
@@ -64,7 +64,7 @@ typedef struct {
  * @param readFunc function pointer to HAL specific read func
  * @param dev_addr i2c device address
  */
-void pca9539_init(pca9539_t *pca, WritePtr writeFunc, ReadPtr readFunc,
+void pca9539_init(pca9539_t *pca, PCA_Write writeFunc, PCA_Read readFunc,
 		  uint8_t dev_addr);
 
 /**

--- a/general/include/pca9539.h
+++ b/general/include/pca9539.h
@@ -39,17 +39,15 @@ PCA 9539 16 bit GPIO expander.  Datasheet: https://www.ti.com/lit/ds/symlink/pca
  * @brief Pointer to write function
  * 
  */
-typedef int (*WritePtr)(uint16_t dev_addr, uint16_t mem_address,
-			uint16_t mem_add_size, uint8_t *data, uint16_t size,
-			int delay);
+typedef uint8_t (*WritePtr)(uint16_t dev_addr, uint8_t reg, uint8_t *data,
+			    uint8_t size);
 
 /**
  * @brief Pointer to read function
  * 
  */
-typedef int (*ReadPtr)(uint16_t dev_addr, uint16_t mem_address,
-		       uint16_t mem_add_size, uint8_t *data, uint16_t size,
-		       int delay);
+typedef uint8_t (*ReadPtr)(uint16_t dev_addr, uint8_t reg, uint8_t *data,
+			   uint8_t size);
 
 typedef struct {
 	WritePtr write;

--- a/general/src/pca9539.c
+++ b/general/src/pca9539.c
@@ -4,25 +4,14 @@
 
 #define REG_SIZE_BITS 8
 
-int pca_write_reg(pca9539_t *pca, uint16_t address, uint8_t *data)
+int pca_write_reg(pca9539_t *pca, uint8_t address, uint8_t *data)
 {
-	//Parameters in the HAL Function
-	uint16_t mem_add_size = 8;
-	uint16_t data_size = 1;
-	int delay = 0xFFFFFFFFU;
-
-	return pca->write(pca->dev_addr, address, mem_add_size, data, data_size,
-			  delay);
+	return pca->write(pca->dev_addr, address, data, 1);
 }
 
-int pca_read_reg(pca9539_t *pca, uint16_t address, uint8_t *data)
+int pca_read_reg(pca9539_t *pca, uint8_t address, uint8_t *data)
 {
-	uint16_t mem_add_size = 8;
-	uint16_t data_size = 1;
-	int delay = 0xFFFFFFFFU;
-
-	return pca->read(pca->dev_addr, address, mem_add_size, data, data_size,
-			 delay);
+	return pca->read(pca->dev_addr, address, data, 1);
 }
 
 void pca9539_init(pca9539_t *pca, WritePtr writeFunc, ReadPtr readFunc,

--- a/general/src/pca9539.c
+++ b/general/src/pca9539.c
@@ -4,17 +4,17 @@
 
 #define REG_SIZE_BITS 8
 
-int pca_write_reg(pca9539_t *pca, uint8_t address, uint8_t *data)
+static int pca_write_reg(pca9539_t *pca, uint8_t address, uint8_t *data)
 {
 	return pca->write(pca->dev_addr, address, data, 1);
 }
 
-int pca_read_reg(pca9539_t *pca, uint8_t address, uint8_t *data)
+static int pca_read_reg(pca9539_t *pca, uint8_t address, uint8_t *data)
 {
 	return pca->read(pca->dev_addr, address, data, 1);
 }
 
-void pca9539_init(pca9539_t *pca, WritePtr writeFunc, ReadPtr readFunc,
+void pca9539_init(pca9539_t *pca, PCA_Write writeFunc, PCA_Read readFunc,
 		  uint8_t dev_addr)
 {
 	pca->dev_addr = dev_addr << 1u;


### PR DESCRIPTION
## Changes

small structural changes to pca driver to remove any references to STM HAL and make it fully platform agnostic

## Notes

There is a follow-up pr in Cerb fixes pdu to use this new driver (has been tested)
