### PR TITLE
Added CAN Messages for MSB Orientation Data in msb.json

### DIFF
--- a/cangen/can-messages/msb.json
+++ b/cangen/can-messages/msb.json
@@ -175,7 +175,7 @@
     "fields": [
       {
         "name": "MSB/FL/WheelTemp",
-        "unit": "C",
+        "unit": "",
         "sim": {
           "min": 0,
           "max": 110,
@@ -185,6 +185,37 @@
         "points": [
           {
             "size": 16
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0x609",
+    "desc": "Front Left MSB Orientation",
+    "sim_freq": 500,
+    "fields": [
+      {
+        "name": "MSB/FL/Orientation",
+        "unit": "Deg",
+        "sim": {
+          "min": -180,
+          "max": 180,
+          "inc_min": 1,
+          "inc_max": 30
+        },
+        "points": [
+          {
+            "size": 16,
+            "signed": true
+          },
+          {
+            "size": 16,
+            "signed": true
+          },
+          {
+            "size": 16,
+            "signed": true
           }
         ]
       }
@@ -212,10 +243,10 @@
       },
       {
         "name": "MSB/FR/Humidity",
-        "unit": "",
+        "unit": "deg",
         "sim": {
           "min": 0,
-          "max": 80,
+          "max": 360,
           "inc_min": 0.01,
           "inc_max": 25
         },

--- a/cangen/can-messages/msb.json
+++ b/cangen/can-messages/msb.json
@@ -243,10 +243,10 @@
       },
       {
         "name": "MSB/FR/Humidity",
-        "unit": "deg",
+        "unit": "",
         "sim": {
           "min": 0,
-          "max": 360,
+          "max": 80,
           "inc_min": 0.01,
           "inc_max": 25
         },
@@ -407,6 +407,37 @@
         "points": [
           {
             "size": 16
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0x629",
+    "desc": "Front Right MSB Orientation",
+    "sim_freq": 500,
+    "fields": [
+      {
+        "name": "MSB/FR/Orientation",
+        "unit": "Deg",
+        "sim": {
+          "min": -180,
+          "max": 180,
+          "inc_min": 1,
+          "inc_max": 30
+        },
+        "points": [
+          {
+            "size": 16,
+            "signed": true
+          },
+          {
+            "size": 16,
+            "signed": true
+          },
+          {
+            "size": 16,
+            "signed": true
           }
         ]
       }
@@ -604,6 +635,37 @@
     ]
   },
   {
+    "id": "0x649",
+    "desc": "Back Left MSB Orientation",
+    "sim_freq": 500,
+    "fields": [
+      {
+        "name": "MSB/BL/Orientation",
+        "unit": "Deg",
+        "sim": {
+          "min": -180,
+          "max": 180,
+          "inc_min": 1,
+          "inc_max": 30
+        },
+        "points": [
+          {
+            "size": 16,
+            "signed": true
+          },
+          {
+            "size": 16,
+            "signed": true
+          },
+          {
+            "size": 16,
+            "signed": true
+          }
+        ]
+      }
+    ]
+  },
+  {
     "id": "0x662",
     "desc": "Back Right MSB Env",
     "sim_freq": 500,
@@ -789,6 +851,37 @@
         "points": [
           {
             "size": 16
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0x669",
+    "desc": "Back Right MSB Orientation",
+    "sim_freq": 500,
+    "fields": [
+      {
+        "name": "MSB/BR/Orientation",
+        "unit": "Deg",
+        "sim": {
+          "min": -180,
+          "max": 180,
+          "inc_min": 1,
+          "inc_max": 30
+        },
+        "points": [
+          {
+            "size": 16,
+            "signed": true
+          },
+          {
+            "size": 16,
+            "signed": true
+          },
+          {
+            "size": 16,
+            "signed": true
           }
         ]
       }


### PR DESCRIPTION
## Changes

Added four CAN messages in msb.json for the Front Right (FR), Front Left (FL), Back Right (BR), and Back Left (BL) MSB board orientation data.

## Test Cases

Verified that the new JSON entries correctly define IMU orientation fields using Calypso.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
