### PR TITLE
Added Overflow Property to Bitstream

### DIFF
--- a/middleware/include/bitstream.h
+++ b/middleware/include/bitstream.h
@@ -4,11 +4,13 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 
 typedef struct {
 	uint8_t *data; // The bitstream data, stored as bytes
 	size_t bytes; // The number of bytes in the bitstream
 	size_t total_bits; // Total number of bits in the bitstream
+	bool overflow; // False by default. If bitstream_add() is called for a value larger than its allotted bits, overflow will be set to true.
 } bitstream_t;
 
 /**

--- a/middleware/include/bitstream.h
+++ b/middleware/include/bitstream.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <math.h>
 
 typedef struct {
 	uint8_t *data; // The bitstream data, stored as bytes
@@ -26,7 +27,7 @@ void bitstream_init(bitstream_t *bitstream, uint8_t *data, size_t bytes);
  * @param *bitstream The bitstream to add data to.
  * @param value The data to add to the bitstream.
  * @param num_bits The length of the data in bits.
- * @return Returns 1 if failed, and 0 if successful.
+ * @return Returns 0 if successful, -1 if there is insufficient space in the bitstream, and 1 if overflow occurs.
  */
 int bitstream_add(bitstream_t *bitstream, uint32_t value, size_t num_bits);
 

--- a/middleware/src/bitstream.c
+++ b/middleware/src/bitstream.c
@@ -5,6 +5,7 @@ void bitstream_init(bitstream_t *bitstream, uint8_t *data, size_t bytes)
 	bitstream->data = data;
 	bitstream->total_bits = 0;
 	bitstream->bytes = bytes;
+	bitstream->overflow = false;
 	memset(bitstream->data, 0, bytes); // Zero out the buffer
 }
 
@@ -12,6 +13,13 @@ int bitstream_add(bitstream_t *bitstream, uint32_t value, size_t num_bits)
 {
 	if (bitstream->total_bits + num_bits > (bitstream->bytes * 8)) {
 		return -1; // Error: not enough space in the bitstream
+	}
+
+	if (value >= pow(2, num_bits)) {
+		bitstream->overflow =
+			true; // Error: value is too large for the number of bits, so set overflow to true.
+		value = pow(2, num_bits) -
+			1; // Cap value to the maximum value that can be stored in the number of bits.
 	}
 
 	for (int i = 0; i < num_bits; ++i) {

--- a/middleware/src/bitstream.c
+++ b/middleware/src/bitstream.c
@@ -28,6 +28,11 @@ int bitstream_add(bitstream_t *bitstream, uint32_t value, size_t num_bits)
 				(1 << (7 - ((bitstream->total_bits + i) % 8)));
 		}
 	}
+
+	if (bitstream->overflow) {
+		return 1; // Overflow occurred
+	}
+
 	bitstream->total_bits += num_bits;
 	return 0; // Success
 }


### PR DESCRIPTION
## Changes
- Added `bool overflow` to the bitstream struct. If `bitstream_add()` is called for a value larger than the maximum possible value for the allotted number of bits, `bitstream->overflow` is set to true. No error is returned, but the value of the input is capped at `pow(2, num_bits) - 1` (rather than overflowing to 0).

## Checklist
- [x] No merge conflicts
- [x] All checks passing
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
