### PR TITLE
Extended CAN IDs

### DIFF
--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -18,6 +18,14 @@ typedef struct {
 	CAN_HandleTypeDef *hcan;
 } can_t;
 
+/**
+ * @brief thing
+ * 
+ * @param id The message's CAN ID. (uint32_t)
+ * @param id_is_extended Denotes whether a standard or extended CAN ID is being used. Defaults to false, so ignore if not using an extended ID. (bool)
+ * @param data The message's data. The maximum is 8 bytes. (uint8_t array)
+ * @param len The length of the data in bytes. (uint8_t)
+ */
 typedef struct {
 	uint32_t id;
 	bool id_is_extended;

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -20,7 +20,7 @@ typedef struct {
 
 typedef struct {
 	uint32_t id;
-	bool is_extended;
+	bool id_is_extended;
 	uint8_t data[8];
 	uint8_t len;
 } can_msg_t;

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -19,7 +19,7 @@ typedef struct {
 } can_t;
 
 /**
- * @brief thing
+ * @brief Struct containing all relavent information for a CAN message.
  * 
  * @param id The message's CAN ID. (uint32_t)
  * @param id_is_extended Denotes whether a standard or extended CAN ID is being used. Defaults to false, so ignore if not using an extended ID. (bool)

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -19,7 +19,7 @@ typedef struct {
 } can_t;
 
 /**
- * @brief Struct containing all relavent information for a CAN message.
+ * @brief Struct containing all relevant information for a CAN message.
  * 
  * @param id The message's CAN ID. (uint32_t)
  * @param id_is_extended Denotes whether a standard or extended CAN ID is being used. Defaults to false, so ignore if not using an extended ID. (bool)

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -39,7 +39,7 @@ HAL_StatusTypeDef can_init(can_t *can);
  * elements.
  * @return HAL_StatusTypeDef Error code.
  */
-HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t id_list[4]);
+HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t id_list[4]);
 
 /**
  * @brief Add CANIDs to the CAN whitelist filter. Up to 8 additions of 2

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -7,6 +7,7 @@
 
 #include "c_utils.h"
 #include "stm32xx_hal.h"
+#include <stdbool.h>
 
 /*
  * NOTE: For implementing callbacks, generate NVIC for selected CAN bus, then
@@ -18,7 +19,11 @@ typedef struct {
 } can_t;
 
 typedef struct {
-	uint32_t id;
+	union {
+		uint16_t standard_id;
+		uint32_t extended_id;
+	} id;
+	bool is_extended;
 	uint8_t data[8];
 	uint8_t len;
 } can_msg_t;
@@ -37,6 +42,5 @@ HAL_StatusTypeDef can_init(can_t *can);
 HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t id_list[4]);
 
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);
-HAL_StatusTypeDef can_send_extended_msg(can_t *can, can_msg_t *msg);
 
 #endif // CAN_H

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -22,7 +22,7 @@ typedef struct {
  * @brief Struct containing all relevant information for a CAN message.
  * 
  * @param id The message's CAN ID. (uint32_t)
- * @param id_is_extended Denotes whether a standard or extended CAN ID is being used. If false, the ID is standard, and vice-versa. (bool)
+ * @param id_is_extended Denotes whether a standard or extended CAN ID is being used. Defaults to false, so ignore if not using an extended ID. (bool)
  * @param data The message's data. The maximum is 8 bytes. (uint8_t array)
  * @param len The length of the data in bytes. (uint8_t)
  */

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -19,10 +19,7 @@ typedef struct {
 } can_t;
 
 typedef struct {
-	union {
-		uint16_t standard_id;
-		uint32_t extended_id;
-	} id;
+	uint32_t id;
 	bool is_extended;
 	uint8_t data[8];
 	uint8_t len;

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -22,7 +22,7 @@ typedef struct {
  * @brief Struct containing all relevant information for a CAN message.
  * 
  * @param id The message's CAN ID. (uint32_t)
- * @param id_is_extended Denotes whether a standard or extended CAN ID is being used. Defaults to false, so ignore if not using an extended ID. (bool)
+ * @param id_is_extended Denotes whether a standard or extended CAN ID is being used. If false, the ID is standard, and vice-versa. (bool)
  * @param data The message's data. The maximum is 8 bytes. (uint8_t array)
  * @param len The length of the data in bytes. (uint8_t)
  */

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -39,7 +39,18 @@ HAL_StatusTypeDef can_init(can_t *can);
  * elements.
  * @return HAL_StatusTypeDef Error code.
  */
-HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t id_list[4]);
+HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t id_list[4]);
+
+/**
+ * @brief Add CANIDs to the CAN whitelist filter. Up to 8 additions of 2
+ * IDs can be done. Only supports CAN extended IDs.
+ * 
+ * @param can CAN datastruct.
+ * @param id_list List of CAN IDs to whitelist. Must be an array of two
+ * elements.
+ * @return HAL_StatusTypeDef Error code.
+ */
+HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t id_list[2]);
 
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);
 

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -82,10 +82,20 @@ HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t id_list[2])
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
 {
 	CAN_TxHeaderTypeDef tx_header;
-	(msg->id_is_extended) ? (tx_header.IDE = CAN_ID_EXT) :
-				(tx_header.IDE = CAN_ID_STD);
-	tx_header.StdId = (msg->id_is_extended) ? 0 : msg->id;
-	tx_header.ExtId = (msg->id_is_extended) ? msg->id : 0;
+
+	if(msg->id == 0) {
+		return -1; // 0 is not a valid CAN ID. It is reserved so standard and extended CAN IDs can be distinguished.
+	}
+
+	if(msg->id_is_extended) {
+		tx_header.IDE = CAN_ID_EXT; // Extended CAN ID
+		tx_header.ExtId = msg->id;
+	}
+	else {
+		tx_header.IDE = CAN_ID_STD; // Standard CAN ID
+		tx_header.StdId = msg->id;
+	}
+
 	tx_header.RTR = CAN_RTR_DATA;
 	tx_header.DLC = msg->len;
 	tx_header.TransmitGlobalTime = DISABLE;

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -83,9 +83,6 @@ HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
 {
 	CAN_TxHeaderTypeDef tx_header;
 
-	if (msg->id == 0)
-		return -1; // 0 is not a valid CAN ID. It is reserved so standard and extended CAN IDs can be distinguished.
-
 	if (msg->id_is_extended) {
 		tx_header.IDE = CAN_ID_EXT; // Extended CAN ID
 		tx_header.ExtId = msg->id;

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -21,7 +21,7 @@ HAL_StatusTypeDef can_init(can_t *can)
 	return err;
 }
 
-HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t id_list[4])
+HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t id_list[4])
 {
 	/* Address of filter bank to store filter */
 	static int filterBank = 0;
@@ -43,6 +43,34 @@ HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t id_list[4])
 	filter.FilterMaskIdLow = id_list[1] << 5u;
 	filter.FilterIdHigh = id_list[2] << 5u;
 	filter.FilterMaskIdHigh = id_list[3] << 5u;
+
+	filter.FilterBank = filterBank;
+
+	filterBank++;
+
+	return HAL_CAN_ConfigFilter(can->hcan, &filter);
+}
+
+HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t id_list[2])
+{
+	/* Address of filter bank to store filter */
+	static int filterBank = 0;
+
+	if (filterBank > 7)
+		return HAL_ERROR;
+
+	CAN_FilterTypeDef filter;
+
+	filter.FilterActivation = ENABLE;
+	filter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
+	filter.FilterScale = CAN_FILTERSCALE_32BIT;
+
+	/* This filter type makes the filter a whitelist */
+	filter.FilterMode = CAN_FILTERMODE_IDLIST;
+
+	/* Add the two IDs. They are shifted left by 3 because extended CAN IDs are 29 bits. */
+	filter.FilterIdHigh = (id_list[0] & 0x1FFFFFFF) << 3;
+	filter.FilterIdLow = (id_list[1] & 0x1FFFFFFF) << 3;
 
 	filter.FilterBank = filterBank;
 

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -54,29 +54,10 @@ HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t id_list[4])
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
 {
 	CAN_TxHeaderTypeDef tx_header;
-	tx_header.StdId = msg->id;
-	tx_header.ExtId = 0;
-	tx_header.IDE = CAN_ID_STD;
-	tx_header.RTR = CAN_RTR_DATA;
-	tx_header.DLC = msg->len;
-	tx_header.TransmitGlobalTime = DISABLE;
-
-	uint32_t tx_mailbox;
-	if (HAL_CAN_GetTxMailboxesFreeLevel(can->hcan) == 0)
-		return HAL_BUSY;
-
-	if (HAL_CAN_AddTxMessage(can->hcan, &tx_header, msg->data, &tx_mailbox))
-		return HAL_ERROR;
-
-	return HAL_OK;
-}
-
-HAL_StatusTypeDef can_send_extended_msg(can_t *can, can_msg_t *msg)
-{
-	CAN_TxHeaderTypeDef tx_header;
-	tx_header.StdId = 0;
-	tx_header.ExtId = msg->id;
-	tx_header.IDE = CAN_ID_EXT;
+	(msg->is_extended) ? (tx_header.IDE = CAN_ID_EXT) :
+			     (tx_header.IDE = CAN_ID_STD);
+	tx_header.StdId = (msg->is_extended) ? 0 : msg->id.standard_id;
+	tx_header.ExtId = (msg->is_extended) ? msg->id.extended_id : 0;
 	tx_header.RTR = CAN_RTR_DATA;
 	tx_header.DLC = msg->len;
 	tx_header.TransmitGlobalTime = DISABLE;

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -82,10 +82,10 @@ HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t id_list[2])
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
 {
 	CAN_TxHeaderTypeDef tx_header;
-	(msg->is_extended) ? (tx_header.IDE = CAN_ID_EXT) :
-			     (tx_header.IDE = CAN_ID_STD);
-	tx_header.StdId = (msg->is_extended) ? 0 : msg->id;
-	tx_header.ExtId = (msg->is_extended) ? msg->id : 0;
+	(msg->id_is_extended) ? (tx_header.IDE = CAN_ID_EXT) :
+				(tx_header.IDE = CAN_ID_STD);
+	tx_header.StdId = (msg->id_is_extended) ? 0 : msg->id;
+	tx_header.ExtId = (msg->id_is_extended) ? msg->id : 0;
 	tx_header.RTR = CAN_RTR_DATA;
 	tx_header.DLC = msg->len;
 	tx_header.TransmitGlobalTime = DISABLE;

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -21,7 +21,7 @@ HAL_StatusTypeDef can_init(can_t *can)
 	return err;
 }
 
-HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t id_list[4])
+HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t id_list[4])
 {
 	/* Address of filter bank to store filter */
 	static int filterBank = 0;

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -84,8 +84,8 @@ HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
 	CAN_TxHeaderTypeDef tx_header;
 	(msg->is_extended) ? (tx_header.IDE = CAN_ID_EXT) :
 			     (tx_header.IDE = CAN_ID_STD);
-	tx_header.StdId = (msg->is_extended) ? 0 : msg->id.standard_id;
-	tx_header.ExtId = (msg->is_extended) ? msg->id.extended_id : 0;
+	tx_header.StdId = (msg->is_extended) ? 0 : msg->id;
+	tx_header.ExtId = (msg->is_extended) ? msg->id : 0;
 	tx_header.RTR = CAN_RTR_DATA;
 	tx_header.DLC = msg->len;
 	tx_header.TransmitGlobalTime = DISABLE;

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -83,15 +83,13 @@ HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
 {
 	CAN_TxHeaderTypeDef tx_header;
 
-	if(msg->id == 0) {
+	if (msg->id == 0)
 		return -1; // 0 is not a valid CAN ID. It is reserved so standard and extended CAN IDs can be distinguished.
-	}
 
-	if(msg->id_is_extended) {
+	if (msg->id_is_extended) {
 		tx_header.IDE = CAN_ID_EXT; // Extended CAN ID
 		tx_header.ExtId = msg->id;
-	}
-	else {
+	} else {
 		tx_header.IDE = CAN_ID_STD; // Standard CAN ID
 		tx_header.StdId = msg->id;
 	}


### PR DESCRIPTION
## Changes
Added support for extended CAN IDs. `can_msg_t` now has a `id_is_extended` bool, which should be manually set when the struct instance is created. The bool is evaluated by `can_send_msg()`, which sends the correct type of message accordingly. Also, a `can_add_filter_extended()` function was created.

## Notes
Not tested yet

## To Do
Implement in the other repos

## Checklist
- [x] No merge conflicts
- [x] All checks passing
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #247 (Once implemented in other repos)
