### PR TITLE
Extended CAN IDs Fix?

### DIFF
--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -56,8 +56,7 @@ static HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t can_id,
  * @param can_id_list_len The length of the list. (uint8_t)
  * @return Error status
  */
-HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t *can_id_list,
-					  uint8_t can_id_list_len);
+HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t can_id_list[]);
 
 /**
  * @brief Adds a list of extended CAN IDs to the filter bank.
@@ -67,8 +66,7 @@ HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t *can_id_list,
  * @param can_id_list_len The length of the list. (uint8_t)
  * @return Error status
  */
-HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t *can_id_list,
-					  uint8_t can_id_list_len);
+HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_id_list[]);
 
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);
 

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -8,7 +8,6 @@
 #include "c_utils.h"
 #include "stm32xx_hal.h"
 #include <stdbool.h>
-#include <math.h>
 
 /*
  * NOTE: For implementing callbacks, generate NVIC for selected CAN bus, then

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -37,8 +37,22 @@ typedef struct {
 
 HAL_StatusTypeDef can_init(can_t *can);
 
+/**
+ * @brief Adds a standard CAN ID filter to the CAN bus. A standard CAN ID filter can contain up to 4 IDs. IDs cannot be larger than 11 bits.
+ * 
+ * @param can The CAN bus to add the filter to. (can_t)
+ * @param can_id_list An array of 4 standard CAN IDs to filter. (uint16_t array)
+ * @return HAL_StatusTypeDef HAL_OK if successful, HAL_ERROR if not. (HAL_StatusTypeDef)
+ */
 HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint16_t can_id_list[4]);
 
+/**
+ * @brief Adds an extended CAN ID filter to the CAN bus. An extended CAN ID filter can contain up to 2 IDs. IDs cannot be larger than 29 bits.
+ * 
+ * @param can The CAN bus to add the filter to. (can_t)
+ * @param can_id_list An array of 2 extended CAN IDs to filter. (uint32_t array)
+ * @return HAL_StatusTypeDef HAL_OK if successful, HAL_ERROR if not. (HAL_StatusTypeDef)
+ */
 HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_id_list[2]);
 
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -16,6 +16,7 @@
 
 typedef struct {
 	CAN_HandleTypeDef *hcan;
+	uint32_t filter_bank;
 } can_t;
 
 /**
@@ -44,8 +45,8 @@ HAL_StatusTypeDef can_init(can_t *can);
  * @return Error status
  * 
  */
-static HAL_StatusTypeDef can_add_filter(CAN_HandleTypeDef *hcan,
-					uint32_t can_id, bool is_extended);
+static HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t can_id,
+					bool is_extended);
 
 /**
  * @brief Adds a list of standard CAN IDs to the filter bank.
@@ -55,8 +56,7 @@ static HAL_StatusTypeDef can_add_filter(CAN_HandleTypeDef *hcan,
  * @param can_id_list_len The length of the list. (uint8_t)
  * @return Error status
  */
-HAL_StatusTypeDef can_add_filter_standard(CAN_HandleTypeDef *hcan,
-					  uint32_t *can_id_list,
+HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t *can_id_list,
 					  uint8_t can_id_list_len);
 
 /**
@@ -67,8 +67,7 @@ HAL_StatusTypeDef can_add_filter_standard(CAN_HandleTypeDef *hcan,
  * @param can_id_list_len The length of the list. (uint8_t)
  * @return Error status
  */
-HAL_StatusTypeDef can_add_filter_extended(CAN_HandleTypeDef *hcan,
-					  uint32_t *can_id_list,
+HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t *can_id_list,
 					  uint8_t can_id_list_len);
 
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -36,26 +36,40 @@ typedef struct {
 HAL_StatusTypeDef can_init(can_t *can);
 
 /**
- * @brief Add CANIDs to the CAN whitelist filter. Up to 7 additions of 4
- * IDs can be done. Only supports CAN standard IDs.
+ * @brief Adds a single CAN ID to the filter bank.
  * 
- * @param can CAN datastruct.
- * @param id_list List of CAN IDs to whitelist. Must be an array of four
- * elements.
- * @return HAL_StatusTypeDef Error code.
+ * @param hcan The CAN handle. (CAN_HandleTypeDef)
+ * @param can_id The CAN ID to add to the filter bank. (uint32_t)
+ * @param is_extended Denotes whether a standard or extended CAN ID is being used. (bool)
+ * @return Error status
+ * 
  */
-HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t id_list[4]);
+static HAL_StatusTypeDef can_add_filter(CAN_HandleTypeDef *hcan,
+					uint32_t can_id, bool is_extended);
 
 /**
- * @brief Add CANIDs to the CAN whitelist filter. Up to 8 additions of 2
- * IDs can be done. Only supports CAN extended IDs.
+ * @brief Adds a list of standard CAN IDs to the filter bank.
  * 
- * @param can CAN datastruct.
- * @param id_list List of CAN IDs to whitelist. Must be an array of two
- * elements.
- * @return HAL_StatusTypeDef Error code.
+ * @param hcan The CAN handle. (CAN_HandleTypeDef)
+ * @param can_id_list The list of CAN IDs. (uint32_t array)
+ * @param can_id_list_len The length of the list. (uint8_t)
+ * @return Error status
  */
-HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t id_list[2]);
+HAL_StatusTypeDef can_add_filter_standard(CAN_HandleTypeDef *hcan,
+					  uint32_t *can_id_list,
+					  uint8_t can_id_list_len);
+
+/**
+ * @brief Adds a list of extended CAN IDs to the filter bank.
+ * 
+ * @param hcan The CAN handle. (CAN_HandleTypeDef)
+ * @param can_id_list The list of CAN IDs. (uint32_t array)
+ * @param can_id_list_len The length of the list. (uint8_t)
+ * @return Error status
+ */
+HAL_StatusTypeDef can_add_filter_extended(CAN_HandleTypeDef *hcan,
+					  uint32_t *can_id_list,
+					  uint8_t can_id_list_len);
 
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);
 

--- a/platforms/stm32f405/include/can.h
+++ b/platforms/stm32f405/include/can.h
@@ -8,6 +8,7 @@
 #include "c_utils.h"
 #include "stm32xx_hal.h"
 #include <stdbool.h>
+#include <math.h>
 
 /*
  * NOTE: For implementing callbacks, generate NVIC for selected CAN bus, then
@@ -36,37 +37,9 @@ typedef struct {
 
 HAL_StatusTypeDef can_init(can_t *can);
 
-/**
- * @brief Adds a single CAN ID to the filter bank.
- * 
- * @param hcan The CAN handle. (CAN_HandleTypeDef)
- * @param can_id The CAN ID to add to the filter bank. (uint32_t)
- * @param is_extended Denotes whether a standard or extended CAN ID is being used. (bool)
- * @return Error status
- * 
- */
-static HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t can_id,
-					bool is_extended);
+HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint16_t can_id_list[4]);
 
-/**
- * @brief Adds a list of standard CAN IDs to the filter bank.
- * 
- * @param hcan The CAN handle. (CAN_HandleTypeDef)
- * @param can_id_list The list of CAN IDs. (uint32_t array)
- * @param can_id_list_len The length of the list. (uint8_t)
- * @return Error status
- */
-HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t can_id_list[]);
-
-/**
- * @brief Adds a list of extended CAN IDs to the filter bank.
- * 
- * @param hcan The CAN handle. (CAN_HandleTypeDef)
- * @param can_id_list The list of CAN IDs. (uint32_t array)
- * @param can_id_list_len The length of the list. (uint8_t)
- * @return Error status
- */
-HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_id_list[]);
+HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_id_list[2]);
 
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);
 

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -51,15 +51,10 @@ HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint16_t can_id_list[4])
 	filter.FilterMaskIdHigh = 0;
 	filter.FilterMaskIdLow = 0;
 
-	uint16_t id1 = (uint16_t)(can_id_list[0] << 5);
-	uint16_t id2 = (uint16_t)(can_id_list[1] << 5);
-	uint16_t id3 = (uint16_t)(can_id_list[2] << 5);
-	uint16_t id4 = (uint16_t)(can_id_list[3] << 5);
-
-	filter.FilterIdHigh = id1;
-	filter.FilterIdLow = id2;
-	filter.FilterMaskIdHigh = id3;
-	filter.FilterMaskIdLow = id4;
+	filter.FilterIdHigh = (uint16_t)(can_id_list[0] << 5);
+	filter.FilterIdLow = (uint16_t)(can_id_list[1] << 5);
+	filter.FilterMaskIdHigh = (uint16_t)(can_id_list[2] << 5);
+	filter.FilterMaskIdLow = (uint16_t)(can_id_list[3] << 5);
 
 	filter.FilterActivation = ENABLE;
 
@@ -85,15 +80,10 @@ HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_id_list[2])
 	filter.FilterMaskIdHigh = 0;
 	filter.FilterMaskIdLow = 0;
 
-	uint32_t id1_high = (can_id_list[0] >> 13);
-	uint32_t id1_low = ((can_id_list[0] << 3) & 0xFFF8) | (1 << 2);
-	uint32_t id2_high = (can_id_list[1] >> 13);
-	uint32_t id2_low = ((can_id_list[1] << 3) & 0xFFF8) | (1 << 2);
-
-	filter.FilterIdHigh = id1_high;
-	filter.FilterIdLow = id1_low;
-	filter.FilterMaskIdHigh = id2_high;
-	filter.FilterMaskIdLow = id2_low;
+	filter.FilterIdHigh = (can_id_list[0] >> 13);
+	filter.FilterIdLow = ((can_id_list[0] << 3) & 0xFFF8) | (1 << 2);
+	filter.FilterMaskIdHigh = (can_id_list[1] >> 13);
+	filter.FilterMaskIdLow = ((can_id_list[1] << 3) & 0xFFF8) | (1 << 2);
 
 	filter.FilterActivation = ENABLE;
 

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -37,8 +37,7 @@ static HAL_StatusTypeDef can_add_filter(CAN_HandleTypeDef *hcan,
 
 	if (is_extended) {
 		filter.FilterIdHigh = (can_id >> 13) & 0xFFFF;
-		filter.FilterIdLow = (can_id << 3) & 0xFFF8;
-		filter.FilterIdLow |= (1 << 2);
+		filter.FilterIdLow = ((can_id << 3) & 0xFFF8) | (1 << 2);
 	} else {
 		filter.FilterIdHigh = (can_id << 5) & 0xFFFF;
 		filter.FilterIdLow = 0;

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -62,6 +62,11 @@ HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t can_id_list[])
 {
 	int size = sizeof(can_id_list) / sizeof(can_id_list[0]);
 	for (uint8_t i = 0; i < size; i++) {
+		if (can_id_list[i] > 0x7FF) {
+			printf("Invalid standard CAN ID at index %d in the CAN ID list. Cannot be larger than 11 bits.\n",
+			       i);
+			return HAL_ERROR;
+		}
 		if (can_add_filter(can, can_id_list[i], false) != HAL_OK) {
 			printf("can_add_filter failed at index %d\n", i);
 			return HAL_ERROR;
@@ -75,9 +80,18 @@ HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_id_list[])
 {
 	int size = sizeof(can_id_list) / sizeof(can_id_list[0]);
 	for (uint8_t i = 0; i < size; i++) {
+		if (can_id_list[i] > 0x1FFFFFFF) {
+			printf("Invalid extended CAN ID at index %d in the CAN ID list. Cannot be larger than 29 bits.\n",
+			       i);
+			return HAL_ERROR;
+		}
 		if (can_add_filter(can, can_id_list[i], true) != HAL_OK) {
 			printf("can_add_filter failed at index %d\n", i);
 			return HAL_ERROR;
+		}
+		if (can_id_list[i] <= 0x7FF) {
+			printf("Warning: A CAN ID smaller than 11 bits was added to the extended filter. This was successful, but make sure the id's 'id_is_extended' property is set to true.\n",
+			       i);
 		}
 	}
 

--- a/platforms/stm32f405/src/can.c
+++ b/platforms/stm32f405/src/can.c
@@ -30,6 +30,7 @@ static HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t can_id,
 	CAN_FilterTypeDef filter;
 
 	if (can->filter_bank >= 14) {
+		printf("Max filter banks reached\n");
 		return HAL_ERROR; // Max of 14 filter banks per CAN instance
 	}
 
@@ -57,11 +58,12 @@ static HAL_StatusTypeDef can_add_filter(can_t *can, uint32_t can_id,
 	return HAL_CAN_ConfigFilter(can->hcan, &filter);
 }
 
-HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t *can_id_list,
-					  uint8_t can_id_list_len)
+HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t can_id_list[])
 {
-	for (uint8_t i = 0; i < can_id_list_len; i++) {
+	int size = sizeof(can_id_list) / sizeof(can_id_list[0]);
+	for (uint8_t i = 0; i < size; i++) {
 		if (can_add_filter(can, can_id_list[i], false) != HAL_OK) {
+			printf("can_add_filter failed at index %d\n", i);
 			return HAL_ERROR;
 		}
 	}
@@ -69,11 +71,12 @@ HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint32_t *can_id_list,
 	return HAL_OK;
 }
 
-HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t *can_id_list,
-					  uint8_t can_id_list_len)
+HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_id_list[])
 {
-	for (uint8_t i = 0; i < can_id_list_len; i++) {
+	int size = sizeof(can_id_list) / sizeof(can_id_list[0]);
+	for (uint8_t i = 0; i < size; i++) {
 		if (can_add_filter(can, can_id_list[i], true) != HAL_OK) {
+			printf("can_add_filter failed at index %d\n", i);
 			return HAL_ERROR;
 		}
 	}


### PR DESCRIPTION
## Changes
Edited how extended CAN IDs are added to filters. Hopefully fixes thing

## Notes
Will test soon

If it works on Shepherd, I'll change the Cerb PR as well

## Checklist
- [x] No merge conflicts
- [ ] All checks passing
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket (fill in the closes line below)
