### PR TITLE
make bitstream not act on prev overflow

### DIFF
--- a/middleware/src/bitstream.c
+++ b/middleware/src/bitstream.c
@@ -32,7 +32,7 @@ int bitstream_add(bitstream_t *bitstream, uint32_t value, size_t num_bits)
 
 	bitstream->total_bits += num_bits;
 
-	if (bitstream->overflow) {
+	if (overflow) {
 		bitstream->overflow = true;
 		return 1; // Overflow occurred
 	}

--- a/middleware/src/bitstream.c
+++ b/middleware/src/bitstream.c
@@ -15,8 +15,9 @@ int bitstream_add(bitstream_t *bitstream, uint32_t value, size_t num_bits)
 		return -1; // Error: not enough space in the bitstream
 	}
 
+	bool overflow = false;
 	if (value >= pow(2, num_bits)) {
-		bitstream->overflow =
+		overflow =
 			true; // Error: value is too large for the number of bits, so set overflow to true.
 		value = pow(2, num_bits) -
 			1; // Cap value to the maximum value that can be stored in the number of bits.
@@ -29,11 +30,13 @@ int bitstream_add(bitstream_t *bitstream, uint32_t value, size_t num_bits)
 		}
 	}
 
+	bitstream->total_bits += num_bits;
+
 	if (bitstream->overflow) {
+		bitstream->overflow = true;
 		return 1; // Overflow occurred
 	}
 
-	bitstream->total_bits += num_bits;
 	return 0; // Success
 }
 


### PR DESCRIPTION
Fixes for segment 24a.

Fix bitstream by ignoring the global overflow state.  also always increment the bits.