### PR TITLE
Bug/faulty lv sense message

### DIFF
--- a/cangen/can-messages/mpu.json
+++ b/cangen/can-messages/mpu.json
@@ -1,4 +1,4 @@
-[
+  [
   {
     "id": "0x501",
     "desc": "MPU Status",
@@ -564,7 +564,7 @@
     "desc": "MPU Sense Voltage",
     "points": [
       {
-        "size": 32,
+        "size": 16,
         "endianness": "little",
         "format": "divide10000",
         "sim": {

--- a/cangen/can-messages/mpu.json
+++ b/cangen/can-messages/mpu.json
@@ -566,7 +566,7 @@
       {
         "size": 16,
         "endianness": "little",
-        "format": "divide10000",
+        "format": "divide100",
         "sim": {
           "min": 22.5,
           "max": 29,


### PR DESCRIPTION
## Changes

Changed CAN message format to make the lv sense voltage send in a 16 bit package and changed the format to "divide100"


## Test Cases

tested that cerberus builds.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] No merge conflicts
- [ ] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
#296
