### PR TITLE
Added filtering to serial

### DIFF
--- a/ner_environment/build_system/build_system.py
+++ b/ner_environment/build_system/build_system.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 # custom modules for functinality that is too large to be included in this script directly
 from .miniterm import main as miniterm
+from .serial2 import main as serial2
 
 # ==============================================================================
 # Typer application setup
@@ -182,6 +183,20 @@ def serial(ls: bool = typer.Option(False, "--list", help='''Specify the device t
         miniterm(ls=True, device=device)
     else:
         miniterm(device=device)
+
+# ==============================================================================
+# Serial2 command
+# ==============================================================================
+
+@app.command(help="Open UART terminal of connected device 2")
+def serial2(
+            ls: bool = typer.Option(False, "--list", help="List available serial devices."),
+            device: str = typer.Option("", "--device", "-d", help="Specify the board to connect to"),
+            filter: str = typer.Option(None, "--filter", "-f", help="Only shows specific messages. Ex. 'ner serial2 -f EXAMPLE' will only show printfs that start with 'EXAMPLE'")):
+    """Custom serial terminal."""
+    
+    serial2(ls=ls, device=device, filter=filter)
+
 
 # ==============================================================================
 # Update command

--- a/ner_environment/build_system/build_system.py
+++ b/ner_environment/build_system/build_system.py
@@ -192,7 +192,7 @@ def serial(ls: bool = typer.Option(False, "--list", help='''Specify the device t
 def serial2(
             ls: bool = typer.Option(False, "--list", help="List available serial devices."),
             device: str = typer.Option("", "--device", "-d", help="Specify the board to connect to."),
-            filter: str = typer.Option(None, "--filter", "-f", help="Only shows specific messages. Ex. ' ner serial2 -f \"EXAMPLE\" ' will only show printfs that contain the substring 'EXAMPLE'. ")):
+            filter: str = typer.Option(None, "--filter", "-f", help="Only shows specific messages. Ex. 'ner serial2 -f EXAMPLE' will only show printfs that contain the substring 'EXAMPLE'. ")):
     """Custom serial terminal."""
     
     serial2_start(ls=ls, device=device, filter=filter)

--- a/ner_environment/build_system/build_system.py
+++ b/ner_environment/build_system/build_system.py
@@ -190,7 +190,7 @@ def serial(ls: bool = typer.Option(False, "--list", help='''Specify the device t
 
 @app.command(help="Open UART terminal of connected device 2")
 def serial2(
-            ls: bool = typer.Option(False, "--list", help="List available serial devices."),
+            ls: bool = typer.Option(False, "--list", help="List available serial devices and exit."),
             device: str = typer.Option("", "--device", "-d", help="Specify the board to connect to."),
             filter: str = typer.Option(None, "--filter", help="Only shows specific messages. Ex. 'ner serial2 --filter EXAMPLE' will only show printfs that contain the substring 'EXAMPLE'. ")):
     """Custom serial terminal."""

--- a/ner_environment/build_system/build_system.py
+++ b/ner_environment/build_system/build_system.py
@@ -191,8 +191,8 @@ def serial(ls: bool = typer.Option(False, "--list", help='''Specify the device t
 @app.command(help="Open UART terminal of connected device 2")
 def serial2(
             ls: bool = typer.Option(False, "--list", help="List available serial devices."),
-            device: str = typer.Option("", "--device", "-d", help="Specify the board to connect to"),
-            filter: str = typer.Option(None, "--filter", "-f", help="Only shows specific messages. Ex. 'ner serial2 -f \"EXAMPLE\"' will only show printfs that start with 'EXAMPLE'")):
+            device: str = typer.Option("", "--device", "-d", help="Specify the board to connect to."),
+            filter: str = typer.Option(None, "--filter", "-f", help="Only shows specific messages. Ex. ' ner serial2 -f \"EXAMPLE\" ' will only show printfs that contain the substring 'EXAMPLE'. ")):
     """Custom serial terminal."""
     
     serial2_start(ls=ls, device=device, filter=filter)

--- a/ner_environment/build_system/build_system.py
+++ b/ner_environment/build_system/build_system.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 # custom modules for functinality that is too large to be included in this script directly
 from .miniterm import main as miniterm
-from .serial2 import main as serial2
+from .serial2 import main as serial2_start
 
 # ==============================================================================
 # Typer application setup
@@ -195,7 +195,7 @@ def serial2(
             filter: str = typer.Option(None, "--filter", "-f", help="Only shows specific messages. Ex. 'ner serial2 -f EXAMPLE' will only show printfs that start with 'EXAMPLE'")):
     """Custom serial terminal."""
     
-    serial2(ls=ls, device=device, filter=filter)
+    serial2_start(ls=ls, device=device, filter=filter)
 
 
 # ==============================================================================

--- a/ner_environment/build_system/build_system.py
+++ b/ner_environment/build_system/build_system.py
@@ -192,11 +192,10 @@ def serial(ls: bool = typer.Option(False, "--list", help='''Specify the device t
 def serial2(
             ls: bool = typer.Option(False, "--list", help="List available serial devices."),
             device: str = typer.Option("", "--device", "-d", help="Specify the board to connect to"),
-            filter: str = typer.Option(None, "--filter", "-f", help="Only shows specific messages. Ex. 'ner serial2 -f EXAMPLE' will only show printfs that start with 'EXAMPLE'")):
+            filter: str = typer.Option(None, "--filter", "-f", help="Only shows specific messages. Ex. 'ner serial2 -f \"EXAMPLE\"' will only show printfs that start with 'EXAMPLE'")):
     """Custom serial terminal."""
     
     serial2_start(ls=ls, device=device, filter=filter)
-
 
 # ==============================================================================
 # Update command

--- a/ner_environment/build_system/build_system.py
+++ b/ner_environment/build_system/build_system.py
@@ -192,7 +192,7 @@ def serial(ls: bool = typer.Option(False, "--list", help='''Specify the device t
 def serial2(
             ls: bool = typer.Option(False, "--list", help="List available serial devices."),
             device: str = typer.Option("", "--device", "-d", help="Specify the board to connect to."),
-            filter: str = typer.Option(None, "--filter", "-f", help="Only shows specific messages. Ex. 'ner serial2 -f EXAMPLE' will only show printfs that contain the substring 'EXAMPLE'. ")):
+            filter: str = typer.Option(None, "--filter", help="Only shows specific messages. Ex. 'ner serial2 --filter EXAMPLE' will only show printfs that contain the substring 'EXAMPLE'. ")):
     """Custom serial terminal."""
     
     serial2_start(ls=ls, device=device, filter=filter)

--- a/ner_environment/build_system/serial2.py
+++ b/ner_environment/build_system/serial2.py
@@ -1,0 +1,68 @@
+import subprocess
+import platform
+import serial
+import sys
+from rich import print
+import serial.tools.list_ports
+
+def list_usb_devices():
+    """List available USB serial devices based on the operating system."""
+    os_name = platform.system()
+    devices = []
+
+    try:
+        if os_name == 'Linux':
+            result = subprocess.run(['ls /dev/tty*'], shell=True, capture_output=True, text=True)
+            devices = [device for device in result.stdout.splitlines() if 'ttyUSB' in device or 'ttyACM' in device]
+            devices.sort(key=lambda x: ('ttyACM' in x, x))  # Prioritize ttyUSB over ttyACM (Aka prioritize FTDI)
+        else:
+            print(f"[bold red]Unsupported operating system: {os_name}[/bold red]", file=sys.stderr)
+            sys.exit(1)
+
+        if not devices:
+            print(f"[bold red]No USB devices found on {os_name}.[/bold red]", file=sys.stderr)
+            sys.exit(1)
+
+    except subprocess.CalledProcessError as e:
+        print(f"[bold red]Failed to execute command to list USB devices: {e}[/bold red]", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"[bold red]An unexpected error occurred: {e}[/bold red]", file=sys.stderr)
+        sys.exit(1)
+
+    return devices
+
+def main(ls=False, device="", filter=None):
+    """Main function for serial communication."""
+    if device == "":
+        devices = list_usb_devices()
+        if ls:
+            print("[bold blue]Devices present:[/bold blue]")
+            for dev in devices:
+                print(f"[green]  - {dev}[/green]")
+            print("[bold blue]The first device will be selected if --device is not specified.[/bold blue]")
+            sys.exit(0)
+
+        # Default to the first device
+        selected_device = devices[0]
+    else:
+        selected_device = device
+
+    print(f"[bold blue]Selected USB device:[/bold blue] [green]{selected_device}[/green]")
+
+    try:
+        with serial.Serial(selected_device, 115200, timeout=1) as ser:
+            print(f"[bold blue]Connected to {selected_device} at 115200 baud.[/bold blue]")
+            if filter:
+                print(f"[bold blue]Filtering messages starting with:[/bold blue] [green]{filter}[/green]")
+            else:
+                print("[bold blue]Displaying all messages.[/bold blue]")
+            while True:
+                line = ser.readline().decode('utf-8', errors='ignore').strip()
+                if not filter or line.startswith(filter):
+                    print(line)
+    except serial.SerialException as e:
+        print(f"[bold red]Failed to open serial port {selected_device}: {e}[/bold red]", file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print("\n[bold blue]Exiting...[/bold blue]")

--- a/ner_environment/build_system/serial2.py
+++ b/ner_environment/build_system/serial2.py
@@ -3,6 +3,7 @@ import platform
 import serial
 import sys
 from rich import print
+from rich.panel import Panel
 import serial.tools.list_ports
 
 def list_usb_devices():

--- a/ner_environment/build_system/serial2.py
+++ b/ner_environment/build_system/serial2.py
@@ -66,3 +66,6 @@ def main(ls=False, device="", filter=None):
         sys.exit(1)
     except KeyboardInterrupt:
         print("\n[bold blue]Exiting...[/bold blue]")
+
+if __name__ == '__main__':
+    main()

--- a/ner_environment/build_system/serial2.py
+++ b/ner_environment/build_system/serial2.py
@@ -59,7 +59,7 @@ def main(ls=False, device="", filter=None):
                 print("[bold blue]Displaying all messages.[/bold blue]")
             while True:
                 line = ser.readline().decode('utf-8', errors='ignore').strip()
-                if not filter or line.startswith(filter):
+                if not filter or (filter in line):
                     print(line)
     except serial.SerialException as e:
         print(f"[bold red]Failed to open serial port {selected_device}: {e}[/bold red]", file=sys.stderr)


### PR DESCRIPTION
## Changes
Added filtering to serial monitor so you don't get spammed by all the other printfs in the repo. The actual command is `ner serial2 --filter` (I kept this stuff separate from the actual `ner serial` command since I was kind of just messing around)

## Notes
Will test soon & may refine some stuff if it works + is actually useful

## Checklist
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
