### PR TITLE
Added signed int support to bitstream

### DIFF
--- a/middleware/include/bitstream.h
+++ b/middleware/include/bitstream.h
@@ -32,13 +32,13 @@ void bitstream_init(bitstream_t *bitstream, uint8_t *data, size_t bytes);
 int bitstream_add(bitstream_t *bitstream, uint32_t value, size_t num_bits);
 
 /**
- * @brief Reads info from the bitstream.
- * @param *bitstream The bitstream to read from.
- * @param start_bit The bit to start reading from.
- * @param num_bits The amount of bits to read. The maximum is 32 bits, and (start_bit + num_bits) must be less than the total number of bits in the bitstream.
- * @return Returns 1 if failed, and 0 if successful.
+ * @brief Adds a signed int to a bitstream. The data is added to the end of the bitstream.
+ * @param *bitstream The bitstream to add data to.
+ * @param value The data to add to the bitstream.
+ * @param num_bits The length of the data in bits.
+ * @return Returns 0 if successful, -1 if there is insufficient space in the bitstream, and 1 if overflow occurs.
  */
-uint32_t bitstream_read(bitstream_t *bitstream, uint32_t start_bit,
-			size_t num_bits);
+int bitstream_add_signed(bitstream_t *bitstream, int32_t value,
+			 size_t num_bits);
 
 #endif // BITSTREAM_H

--- a/middleware/src/bitstream.c
+++ b/middleware/src/bitstream.c
@@ -63,11 +63,13 @@ int bitstream_add_signed(bitstream_t *bitstream, int32_t value, size_t num_bits)
 		}
 	}
 
-	/* Convert to unsigned representation for bit manipulation */
-	uint32_t unsigned_value = (uint32_t)value;
+	/* Create a mask for the num_bits we want to extract */
+	uint32_t mask = (1u << num_bits) - 1;
+	/* Extract the bits we want, including the sign bit */
+	uint32_t bits = (uint32_t)value & mask;
 
 	for (int i = 0; i < num_bits; ++i) {
-		if (unsigned_value & (1u << (num_bits - 1 - i))) {
+		if (bits & (1u << (num_bits - 1 - i))) {
 			bitstream->data[(bitstream->total_bits + i) / 8] |=
 				(1 << (7 - ((bitstream->total_bits + i) % 8)));
 		}


### PR DESCRIPTION
## Changes
Added signed int support to bitstream.c using _Generic. bitstream_add() is a macro now, but everything should still work the same. I also removed bitstream_read() since it's not really useful and would probably just be confusing now that bitstream also supports signed ints.

## Notes
Not tested yet

## Checklist
- [x] No merge conflicts
- [x] All checks passing
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack