### PR TITLE
Added FDCAN support for STM32H563

### DIFF
--- a/platforms/stm32h563/include/fdcan.h
+++ b/platforms/stm32h563/include/fdcan.h
@@ -1,0 +1,36 @@
+#ifndef FDCAN_H
+#define FDCAN_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "stm32xx_hal.h"
+
+/* function pointer type for the callback */
+typedef void (*can_callback_t)(FDCAN_HandleTypeDef *hcan);
+
+typedef struct {
+	FDCAN_HandleTypeDef *hcan;
+
+	const uint16_t *standard_id_list;
+    uint8_t standard_id_list_len;
+
+    const uint32_t *extended_id_list;
+    uint8_t extended_id_list_len;
+
+	/* desired behavior varies by app - so implement this at app level */
+	can_callback_t callback;
+} can_t;
+
+typedef struct {
+	uint32_t id;
+	uint8_t data[8]; // technically can go to 64 but cannot count that high
+    bool id_is_extended;
+	uint8_t len;
+} can_msg_t;
+
+HAL_StatusTypeDef can_init(can_t *can);
+HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);
+
+#endif // FDCAN_H

--- a/platforms/stm32h563/include/fdcan.h
+++ b/platforms/stm32h563/include/fdcan.h
@@ -1,6 +1,7 @@
 #ifndef FDCAN_H
 #define FDCAN_H
 
+// clang-format off
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -31,4 +32,5 @@ HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);
 HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint16_t can_ids[2]);
 HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_ids[2]);
 
+// clang-format on
 #endif // FDCAN_H

--- a/platforms/stm32h563/include/fdcan.h
+++ b/platforms/stm32h563/include/fdcan.h
@@ -7,18 +7,20 @@
 
 #include "stm32xx_hal.h"
 
-typedef struct {
+typedef struct
+{
 	uint32_t id;
 	uint8_t data[8]; // technically can go to 64 bytes but i cant count that high
-    bool id_is_extended;
+	bool id_is_extended;
 	uint8_t len;
 } can_msg_t;
 
 typedef void (*can_callback_t)(can_msg_t *message);
 
-typedef struct {
+typedef struct
+{
 	FDCAN_HandleTypeDef *hcan;
-	
+
 	uint32_t standard_filter_index;
 	uint32_t extended_filter_index;
 	can_callback_t callback; // callback function that can be configured in the application layer.

--- a/platforms/stm32h563/include/fdcan.h
+++ b/platforms/stm32h563/include/fdcan.h
@@ -7,30 +7,26 @@
 
 #include "stm32xx_hal.h"
 
-/* function pointer type for the callback */
-typedef void (*can_callback_t)(FDCAN_HandleTypeDef *hcan);
-
-typedef struct {
-	FDCAN_HandleTypeDef *hcan;
-
-	const uint16_t *standard_id_list;
-    uint8_t standard_id_list_len;
-
-    const uint32_t *extended_id_list;
-    uint8_t extended_id_list_len;
-
-	/* desired behavior varies by app - so implement this at app level */
-	can_callback_t callback;
-} can_t;
-
 typedef struct {
 	uint32_t id;
-	uint8_t data[8]; // technically can go to 64 but cannot count that high
+	uint8_t data[8]; // technically can go to 64 bytes but i cant count that high
     bool id_is_extended;
 	uint8_t len;
 } can_msg_t;
 
-HAL_StatusTypeDef can_init(can_t *can);
+typedef void (*can_callback_t)(can_msg_t *message);
+
+typedef struct {
+	FDCAN_HandleTypeDef *hcan;
+	
+	uint32_t standard_filter_index;
+	uint32_t extended_filter_index;
+	can_callback_t callback; // callback function that can be configured in the application layer.
+} can_t;
+
+HAL_StatusTypeDef can_init(can_t *can, can_callback_t callback);
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);
+HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint16_t can_ids[2]);
+HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_ids[2]);
 
 #endif // FDCAN_H

--- a/platforms/stm32h563/include/fdcan.h
+++ b/platforms/stm32h563/include/fdcan.h
@@ -16,18 +16,15 @@ typedef struct
 	uint8_t len;
 } can_msg_t;
 
-typedef void (*can_callback_t)(can_msg_t *message);
-
 typedef struct
 {
 	FDCAN_HandleTypeDef *hcan;
 
 	uint32_t standard_filter_index;
 	uint32_t extended_filter_index;
-	can_callback_t callback; // callback function that can be configured in the application layer.
 } can_t;
 
-HAL_StatusTypeDef can_init(can_t *can, can_callback_t callback);
+HAL_StatusTypeDef can_init(can_t *can);
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg);
 HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint16_t can_ids[2]);
 HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_ids[2]);

--- a/platforms/stm32h563/include/stm32xx_hal.h
+++ b/platforms/stm32h563/include/stm32xx_hal.h
@@ -1,0 +1,24 @@
+#ifndef STM32XX_HAL_H
+#define STM32XX_HAL_H
+
+#ifdef STM32F405xx
+#include "stm32f4xx_hal.h"
+#endif
+
+#ifdef STM32H745xx
+#include "stm32h7xx_hal.h"
+#endif
+
+#ifdef STM32G431xx
+#include "stm32g4xx_hal.h"
+#endif
+
+#ifdef STM32F103xB
+#include "stm32f1xx_hal.h"
+#endif
+
+#ifdef STM32H563xx
+#include "stm32h5xx_hal.h"
+#endif
+
+#endif /* STM32XX_HAL_H*/

--- a/platforms/stm32h563/include/stm32xx_hal.h
+++ b/platforms/stm32h563/include/stm32xx_hal.h
@@ -1,20 +1,12 @@
 #ifndef STM32XX_HAL_H
 #define STM32XX_HAL_H
 
-#ifdef STM32F405xx
-#include "stm32f4xx_hal.h"
-#endif
-
 #ifdef STM32H745xx
 #include "stm32h7xx_hal.h"
 #endif
 
 #ifdef STM32G431xx
 #include "stm32g4xx_hal.h"
-#endif
-
-#ifdef STM32F103xB
-#include "stm32f1xx_hal.h"
 #endif
 
 #ifdef STM32H563xx

--- a/platforms/stm32h563/src/fdcan.c
+++ b/platforms/stm32h563/src/fdcan.c
@@ -1,0 +1,115 @@
+#include "fdcan.h"
+#include <stdint.h>
+#include <string.h>
+
+/* NOTE: STM32H563 will have MAX of 2 CAN buses */
+/* (assuming i have read the datasheet correctly) */
+#define MAX_CAN_BUS 2
+
+can_t *can_struct_list[MAX_CAN_BUS] = { NULL, NULL, NULL };
+
+static can_callback_t find_callback(FDCAN_HandleTypeDef *hcan)
+{
+	for (uint8_t i = 0; i < MAX_CAN_BUS; i++) {
+		if (hcan == can_struct_list[i]->hcan)
+			return can_struct_list[i]->callback;
+	}
+	return NULL;
+}
+
+/* Add a CAN interfae to be searched for during the event of a callback */
+static uint8_t add_interface(can_t *interface)
+{
+	for (uint8_t i = 0; i < MAX_CAN_BUS; i++) {
+		/* Interface already added */
+		if (interface->hcan == can_struct_list[i]->hcan)
+			return -1;
+
+		/* If empty, add interface */
+		if (can_struct_list[i]->hcan == NULL) {
+			can_struct_list[i] = interface;
+			return 0;
+		}
+	}
+
+	/* No open slots, something is wrong */
+	return -2;
+}
+
+/* Run callback function when there a new message is received */
+void HAL_FDCAN_RxFifo0Callback(FDCAN_HandleTypeDef *hcan, uint32_t RxFifo0ITs)
+{
+	/* Handle CAN reception event */
+	can_callback_t callback = find_callback(hcan);
+
+	if (callback != NULL) {
+		callback(hcan);
+	}
+}
+
+HAL_StatusTypeDef can_init(can_t *can)
+{
+	/* set up filter */
+	uint16_t high_id = can->id_list[0];
+	uint16_t low_id = can->id_list[0];
+
+	for (uint8_t i = 0; i < can->id_list_len; i++) {
+		if (can->id_list[i] > high_id)
+			high_id = can->id_list[i];
+		if (can->id_list[i] < low_id)
+			low_id = can->id_list[i];
+	}
+
+	uint32_t full_id = ((uint32_t)high_id << 16) | low_id;
+
+	FDCAN_FilterTypeDef sFilterConfig;
+
+	sFilterConfig.IdType = FDCAN_STANDARD_ID;
+	sFilterConfig.FilterIndex = 0;
+	sFilterConfig.FilterType = FDCAN_FILTER_RANGE;
+	sFilterConfig.FilterConfig = FDCAN_FILTER_DISABLE;
+	sFilterConfig.FilterID1 = 0x0;
+	sFilterConfig.FilterID2 = 0x7FF;
+
+	uint8_t err = 0;
+	err = HAL_FDCAN_ConfigFilter(can->hcan, &sFilterConfig);
+	if (err != HAL_OK)
+		return err;
+
+	/* set up interrupt & activate CAN */
+	err = HAL_FDCAN_Start(can->hcan);
+	if (err != HAL_OK)
+		return err;
+
+	/* Override the default callback for FDCAN_IT_LIST_RX_FIFO0 */
+	// err = HAL_FDCAN_ActivateNotification(can->hcan, FDCAN_IT_LIST_RX_FIFO0);
+	err = add_interface(can);
+
+	return err;
+}
+
+HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
+{
+	FDCAN_TxHeaderTypeDef tx_header;
+	tx_header.Identifier = msg->id;
+    tx_header.TxFrameType = FDCAN_DATA_FRAME;
+	tx_header.DataLength = msg->len;
+	tx_header.ErrorStateIndicator = FDCAN_ESI_ACTIVE;
+	tx_header.BitRateSwitch = FDCAN_BRS_OFF;
+	tx_header.FDFormat = FDCAN_CLASSIC_CAN;
+
+    /* Check if extended or not extended */
+    if(msg->id_is_extended)
+        tx_header.IdType = FDCAN_EXTENDED_ID;
+    else
+        tx_header.IdType = FDCAN_STANDARD_ID;
+
+	uint32_t tx_mailbox;
+	if (HAL_FDCAN_GetTxFifoFreeLevel(can->hcan) == 0)
+		return HAL_BUSY;
+
+	if (HAL_FDCAN_AddMessageToTxFifoQ(can->hcan, &tx_header, &msg->data))
+		return HAL_ERROR;
+
+	return HAL_OK;
+}

--- a/platforms/stm32h563/src/fdcan.c
+++ b/platforms/stm32h563/src/fdcan.c
@@ -194,13 +194,10 @@ HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
 	else
 		tx_header.IdType = FDCAN_STANDARD_ID;
 
-	uint32_t status = HAL_FDCAN_GetTxFifoFreeLevel(can->hcan);
-	if (status != 0) {
-		printf("[fdcan.c/can_send_msg()] ERROR: HAL_FDCAN_GetTxFifoFreeLevel() failed (Status: %d, Message ID: %d).\n", status, msg->id);
-		return status;
-	}
-
-	status = HAL_FDCAN_AddMessageToTxFifoQ(can->hcan, &tx_header, msg->data);
+	if (HAL_FDCAN_GetTxFifoFreeLevel(can->hcan) == 0)
+		return HAL_BUSY;
+	
+	HAL_StatusTypeDef status = HAL_FDCAN_AddMessageToTxFifoQ(can->hcan, &tx_header, msg->data);
 	if (status != HAL_OK) {
 		printf("[fdcan.c/can_send_msg()] ERROR: HAL_FDCAN_AddMessageToTxFifoQ() failed (Status: %d, Message ID: %d).\n", status, msg->id);
 		return status;

--- a/platforms/stm32h563/src/fdcan.c
+++ b/platforms/stm32h563/src/fdcan.c
@@ -5,11 +5,12 @@
 /* NOTE: STM32H563 will have MAX of 2 CAN buses */
 #define MAX_CAN_BUS 2
 
-can_t *can_struct_list[MAX_CAN_BUS] = { NULL, NULL };
+can_t *can_struct_list[MAX_CAN_BUS] = {NULL, NULL};
 
 static can_callback_t find_callback(FDCAN_HandleTypeDef *hcan)
 {
-	for (uint8_t i = 0; i < MAX_CAN_BUS; i++) {
+	for (uint8_t i = 0; i < MAX_CAN_BUS; i++)
+	{
 		if ((can_struct_list[i] != NULL) && (hcan == can_struct_list[i]->hcan))
 			return can_struct_list[i]->callback;
 	}
@@ -19,13 +20,15 @@ static can_callback_t find_callback(FDCAN_HandleTypeDef *hcan)
 /* Add a CAN interfae to be searched for during the event of a callback */
 static uint8_t add_interface(can_t *interface)
 {
-	for (uint8_t i = 0; i < MAX_CAN_BUS; i++) {
+	for (uint8_t i = 0; i < MAX_CAN_BUS; i++)
+	{
 		/* Interface already added */
 		if ((can_struct_list[i] != NULL) && (interface->hcan == can_struct_list[i]->hcan))
 			return -1;
 
 		/* If empty, add interface */
-		if (can_struct_list[i] == NULL) {
+		if (can_struct_list[i] == NULL)
+		{
 			can_struct_list[i] = interface;
 			return 0;
 		}
@@ -35,7 +38,8 @@ static uint8_t add_interface(can_t *interface)
 	return -2;
 }
 
-HAL_StatusTypeDef can_init(can_t *can, can_callback_t callback) {
+HAL_StatusTypeDef can_init(can_t *can, can_callback_t callback)
+{
 
 	/* Init these guys to 0 */
 	can->standard_filter_index = 0;
@@ -46,28 +50,32 @@ HAL_StatusTypeDef can_init(can_t *can, can_callback_t callback) {
 
 	/* Start FDCAN */
 	HAL_StatusTypeDef status = HAL_FDCAN_Start(can->hcan);
-	if (status != HAL_OK) {
+	if (status != HAL_OK)
+	{
 		printf("[fdcan.c/can_init()] ERROR: Failed to run HAL_FDCAN_Start() (Status: %d).\n", status);
 		return status;
 	}
 
 	/* Config interrupts */
 	status = HAL_FDCAN_ConfigInterruptLines(can->hcan, FDCAN_IT_RX_FIFO0_NEW_MESSAGE, FDCAN_INTERRUPT_LINE0);
-	if(status != HAL_OK) {
+	if (status != HAL_OK)
+	{
 		printf("[fdcan.c/can_init()] ERROR: Failed to run HAL_FDCAN_ConfigInterruptLines() (Status: %d).\n", status);
 		return status;
 	}
-	
+
 	/* Activate interrupt notifications */
 	status = HAL_FDCAN_ActivateNotification(can->hcan, FDCAN_IT_RX_FIFO0_NEW_MESSAGE, 0);
-	if(status != HAL_OK) {
+	if (status != HAL_OK)
+	{
 		printf("[fdcan.c/can_init()] ERROR: Failed to run HAL_FDCAN_ActivateNotification() (Status: %d).\n", status);
 		return status;
 	}
 
 	/* Add can_t instance to this file's can_t tracker */
 	status = add_interface(can);
-	if(status != 0) {
+	if (status != 0)
+	{
 		printf("[fdcan.c/can_init()] ERROR: Failed to add a can_t instance to the can_t tracker (Status: %d).\n", status);
 		return status;
 	}
@@ -76,37 +84,44 @@ HAL_StatusTypeDef can_init(can_t *can, can_callback_t callback) {
 }
 
 /* Callback for any FIFO0 interrupt stuff */
-void HAL_FDCAN_RxFifo0Callback(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo0ITs) {
-    
+void HAL_FDCAN_RxFifo0Callback(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo0ITs)
+{
+
 	/* If a message has just been recieved... */
-	if (RxFifo0ITs & FDCAN_IT_RX_FIFO0_NEW_MESSAGE) {
-        can_msg_t message;
+	if (RxFifo0ITs & FDCAN_IT_RX_FIFO0_NEW_MESSAGE)
+	{
+		can_msg_t message;
 		FDCAN_RxHeaderTypeDef rx_header;
 
-		if(HAL_FDCAN_GetRxMessage(hfdcan, FDCAN_RX_FIFO0, &rx_header, message.data) == HAL_OK) {
+		if (HAL_FDCAN_GetRxMessage(hfdcan, FDCAN_RX_FIFO0, &rx_header, message.data) == HAL_OK)
+		{
 			message.id = rx_header.Identifier;
 			message.id_is_extended = (rx_header.IdType == FDCAN_EXTENDED_ID);
 			message.len = (uint8_t)rx_header.DataLength;
 
 			/* Check size */
-			if(rx_header.DataLength > 8) {
-    			printf("[fdcan.c/HAL_FDCAN_RxFifo0Callback()] ERROR: Recieved message is larger than 8 bytes.\n");
-    			return;
+			if (rx_header.DataLength > 8)
+			{
+				printf("[fdcan.c/HAL_FDCAN_RxFifo0Callback()] ERROR: Recieved message is larger than 8 bytes.\n");
+				return;
 			}
 
 			/* Send message to the application layer via the configured callback */
 			can_callback_t callback = find_callback(hfdcan);
-			if(callback != NULL) {
+			if (callback != NULL)
+			{
 				callback(&message);
 			}
-			else {
+			else
+			{
 				printf("[fdcan.c/HAL_FDCAN_RxFifo0Callback()] ERROR: callback() is null.\n");
 			}
-		} 
-    }
+		}
+	}
 }
 
-HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint16_t can_ids[2]) {
+HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint16_t can_ids[2])
+{
 	FDCAN_FilterTypeDef filter;
 
 	/* Config the filter */
@@ -116,10 +131,11 @@ HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint16_t can_ids[2]) {
 	filter.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
 	filter.FilterID1 = can_ids[0];
 	filter.FilterID2 = can_ids[1];
-	
+
 	/* Send HAL the config, and check if it was sucessful */
-	HAL_StatusTypeDef status = HAL_FDCAN_ConfigFilter(can->hcan, &filter); 
-	if(status != HAL_OK) {
+	HAL_StatusTypeDef status = HAL_FDCAN_ConfigFilter(can->hcan, &filter);
+	if (status != HAL_OK)
+	{
 		printf("[fdcan.c/can_add_filter_standard()] ERROR: Failed to config standard FDCAN filter (Status: %d, Filter Index: %d).\n", status, filter.FilterIndex);
 		return status;
 	}
@@ -127,10 +143,10 @@ HAL_StatusTypeDef can_add_filter_standard(can_t *can, uint16_t can_ids[2]) {
 	/* If successful, increment the standard filter index */
 	can->standard_filter_index++;
 	return status;
-	
 }
 
-HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_ids[2]) {
+HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_ids[2])
+{
 	FDCAN_FilterTypeDef filter;
 
 	/* Config the filter */
@@ -140,10 +156,11 @@ HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_ids[2]) {
 	filter.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
 	filter.FilterID1 = can_ids[0];
 	filter.FilterID2 = can_ids[1];
-	
+
 	/* Send HAL the config, and check if it was sucessful */
-	HAL_StatusTypeDef status = HAL_FDCAN_ConfigFilter(can->hcan, &filter); 
-	if(status != HAL_OK) {
+	HAL_StatusTypeDef status = HAL_FDCAN_ConfigFilter(can->hcan, &filter);
+	if (status != HAL_OK)
+	{
 		printf("[fdcan.c/can_add_filter_extended()] ERROR: Failed to config extended FDCAN filter (Status: %d, Filter Index: %d). \n", status, filter.FilterIndex);
 		return status;
 	}
@@ -151,40 +168,40 @@ HAL_StatusTypeDef can_add_filter_extended(can_t *can, uint32_t can_ids[2]) {
 	/* If successful, increment the extended filter index */
 	can->extended_filter_index++;
 	return status;
-	
 }
 
 HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
 {
 	/* Validate message length */
-    if (msg->len > 8) {
-        printf("[fdcan.c/can_send_msg()] ERROR: FDCAN message length exceeds 8 bytes (Length: %d, Message ID: %d).\n", msg->len, msg->id);
-        return HAL_ERROR;
-    }
+	if (msg->len > 8)
+	{
+		printf("[fdcan.c/can_send_msg()] ERROR: FDCAN message length exceeds 8 bytes (Length: %d, Message ID: %d).\n", msg->len, msg->id);
+		return HAL_ERROR;
+	}
 
 	FDCAN_TxHeaderTypeDef tx_header;
 	tx_header.Identifier = msg->id;
 	tx_header.DataLength = msg->len;
-    tx_header.TxFrameType = FDCAN_DATA_FRAME;
+	tx_header.TxFrameType = FDCAN_DATA_FRAME;
 	tx_header.ErrorStateIndicator = FDCAN_ESI_ACTIVE;
 	tx_header.BitRateSwitch = FDCAN_BRS_OFF;
 	tx_header.FDFormat = FDCAN_CLASSIC_CAN;
 
-    /* Check if extended or not extended */
-    if(msg->id_is_extended)
-        tx_header.IdType = FDCAN_EXTENDED_ID;
-    else
-        tx_header.IdType = FDCAN_STANDARD_ID;
+	/* Check if extended or not extended */
+	if (msg->id_is_extended)
+		tx_header.IdType = FDCAN_EXTENDED_ID;
+	else
+		tx_header.IdType = FDCAN_STANDARD_ID;
 
 	HAL_StatusTypeDef status = HAL_FDCAN_GetTxFifoFreeLevel(can->hcan);
 	if (status != HAL_OK)
 		printf("[fdcan.c/can_send_msg()] ERROR: HAL_FDCAN_GetTxFifoFreeLevel() failed (Status: %d, Message ID: %d).\n", status, msg->id);
-		return status;
+	return status;
 
 	status = HAL_FDCAN_AddMessageToTxFifoQ(can->hcan, &tx_header, msg->data);
 	if (status != HAL_OK)
 		printf("[fdcan.c/can_send_msg()] ERROR: HAL_FDCAN_AddMessageToTxFifoQ() failed (Status: %d, Message ID: %d).\n", status, msg->id);
-		return status;
+	return status;
 
 	return status;
 }

--- a/platforms/stm32h563/src/fdcan.c
+++ b/platforms/stm32h563/src/fdcan.c
@@ -74,11 +74,11 @@ HAL_StatusTypeDef can_init(can_t *can, can_callback_t callback)
 	}
 
 	/* Add can_t instance to this file's can_t tracker */
-	status = add_interface(can);
-	if (status != 0)
+	uint8_t interface_status = add_interface(can);
+	if (interface_status != 0)
 	{
 		printf("[fdcan.c/can_init()] ERROR: Failed to add a can_t instance to the can_t tracker (Status: %d).\n", status);
-		return status;
+		return interface_status;
 	}
 
 	return status;

--- a/platforms/stm32h563/src/fdcan.c
+++ b/platforms/stm32h563/src/fdcan.c
@@ -1,3 +1,4 @@
+// clang-format off
 #include "fdcan.h"
 #include <stdint.h>
 #include <string.h>
@@ -24,7 +25,7 @@ static uint8_t add_interface(can_t *interface)
 	{
 		/* Interface already added */
 		if ((can_struct_list[i] != NULL) && (interface->hcan == can_struct_list[i]->hcan))
-			return -1;
+			return 1;
 
 		/* If empty, add interface */
 		if (can_struct_list[i] == NULL)
@@ -35,7 +36,7 @@ static uint8_t add_interface(can_t *interface)
 	}
 
 	/* No open slots, something is wrong */
-	return -2;
+	return 2;
 }
 
 HAL_StatusTypeDef can_init(can_t *can, can_callback_t callback)
@@ -193,15 +194,17 @@ HAL_StatusTypeDef can_send_msg(can_t *can, can_msg_t *msg)
 	else
 		tx_header.IdType = FDCAN_STANDARD_ID;
 
-	HAL_StatusTypeDef status = HAL_FDCAN_GetTxFifoFreeLevel(can->hcan);
-	if (status != HAL_OK)
+	uint32_t status = HAL_FDCAN_GetTxFifoFreeLevel(can->hcan);
+	if (status != 0) {
 		printf("[fdcan.c/can_send_msg()] ERROR: HAL_FDCAN_GetTxFifoFreeLevel() failed (Status: %d, Message ID: %d).\n", status, msg->id);
-	return status;
+		return status;
+	}
 
 	status = HAL_FDCAN_AddMessageToTxFifoQ(can->hcan, &tx_header, msg->data);
-	if (status != HAL_OK)
+	if (status != HAL_OK) {
 		printf("[fdcan.c/can_send_msg()] ERROR: HAL_FDCAN_AddMessageToTxFifoQ() failed (Status: %d, Message ID: %d).\n", status, msg->id);
-	return status;
+		return status;
+	}
 
 	return status;
 }


### PR DESCRIPTION
Created two new files:
`platforms/stm32h563/fdcan.h`
`platforms/stm32h563/fdcan.c`

These files were based off of the stm32g431 FDCAN files, but changes were made to make the API more similar to STM32F4 `can.c`.

Obv not tested yet.