### PR TITLE
Changed STM32 HAL #include to not be platform-specific

### DIFF
--- a/middleware/include/timer.h
+++ b/middleware/include/timer.h
@@ -1,7 +1,7 @@
 #ifndef TIMER_H
 #define TIMER_H
 
-#include "stm32f4xx_hal.h"
+#include "stm32xx_hal.h"
 #include <stdbool.h>
 
 typedef struct {


### PR DESCRIPTION
Changed STM32 HAL #include to not be platform-specific so you can use `timer.h` in any repo