### PR TITLE
Added #include <stdint.h> to timer.h

### DIFF
--- a/middleware/include/timer.h
+++ b/middleware/include/timer.h
@@ -2,6 +2,7 @@
 #define TIMER_H
 
 #include "stm32xx_hal.h"
+#include <stdint.h>
 #include <stdbool.h>
 
 typedef struct {


### PR DESCRIPTION
Added `#include <stdint.h>` in timer.h to fix build errors.