### PR TITLE
Added mutex_isOwned() function

### DIFF
--- a/threadX/inc/u_tx_mutex.h
+++ b/threadX/inc/u_tx_mutex.h
@@ -25,5 +25,7 @@ typedef struct {
 uint8_t create_mutex(mutex_t *mutex); // Create a mutex
 uint8_t mutex_get(mutex_t *mutex); // Gets a mutex.
 uint8_t mutex_put(mutex_t *mutex); // Puts a mutex.
+bool mutex_isOwned(
+	mutex_t *mutex); // Checks if a mutex is owned by the current thread.
 
 #endif /* u_tx_queues.h */

--- a/threadX/src/u_tx_mutex.c
+++ b/threadX/src/u_tx_mutex.c
@@ -39,4 +39,17 @@ uint8_t mutex_put(mutex_t *mutex)
 	return U_SUCCESS;
 }
 
+/* Checks if a mutex is owned by the current thread. */
+bool mutex_isOwned(mutex_t *mutex) {
+	TX_THREAD* mutex_thread; // Thread that currently owns the mutex.
+	uint8_t status = tx_mutex_info_get(&mutex->_TX_MUTEX, TX_NULL, TX_NULL, &mutex_thread, TX_NULL, TX_NULL, TX_NULL);
+	if(status != TX_SUCCESS) {
+		PRINTLN_ERROR("Failed to call tx_mutex_info_get() (Status: %d/%s, Mutex: %s).", status, tx_status_toString(status), mutex->name);
+		return false;
+	}
+
+	TX_THREAD* current_thread = tx_thread_identify(); // The current active thread (i.e., the thread that called mutex_isOwned()).
+	return (mutex_thread == current_thread); // If mutex_thread is the same as current_thread, return true. If not, return false.
+}
+
 // clang-format on


### PR DESCRIPTION
Added `mutex_isOwned(mutex_t* mutex)`, which checks if the passed-in mutex is owned by the current thread. Returns true if so, and false if not.