### PR TITLE
fixed build system not returning docker command

### DIFF
--- a/ner_environment/build_system/build_system.py
+++ b/ner_environment/build_system/build_system.py
@@ -359,7 +359,6 @@ def usbip(connect: bool = typer.Option(False, "--connect", help="Connect to a US
 # ==============================================================================
 
 def run_command(command, stream_output=False, exit_on_fail=False) -> int:
-    # print("guess who isn't fucked rn") # REMOVEME
     """Run a shell command. Optionally stream the output in real-time. Returns the returncode of the command called"""
     if stream_output:
 


### PR DESCRIPTION
## Changes

`ner build` and `ner test` now return the exit code of the docker command as opposed to just `0`

## Notes

The rationale for this change was to allow command chaning such as `ner build && ner flash` 

## Test Cases

- `ner build` on a functional Cerberus-2.0 returns 0
- `ner build` on a broken Cerberus-2.0 returns the error code of the compiler 

## To Do
This is a minor change that shouldn't require continuing effort

## Checklist

- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #364 
