### PR TITLE
Added LAN8670_Read_PHY_ID1() and LAN8670_Read_Model_Number() to LAN8670 PHY Driver

### DIFF
--- a/general/include/lan8670.h
+++ b/general/include/lan8670.h
@@ -210,4 +210,22 @@ int32_t LAN8670_PLCA_ReadTOTMR(lan8670_t *lan, bool *buffer); // NOTE: This func
  */
 int32_t LAN8670_PLCA_WriteTOTMR(lan8670_t *lan, uint8_t data); // NOTE: This function has not been tested yet (as of 01/31/2026).
 
+/**
+ * @brief Returns the value of the PHY_ID1 register. This register contains the first 16 bits of the OUI (Organizationally Unique Identifier). Should be: 0b0000000000000111 in reset according to the datasheet.
+ * 
+ * @param lan Pointer to the lan8670_t instance.
+ * @param data Buffer for the register value.
+ * @return Status.
+ */
+int32_t LAN8670_Read_PHY_ID1(lan8670_t *lan, uint16_t *data);
+
+/**
+ * @brief Returns the PHY manufacturer's model number. Should be 0b00010110 for the LAN8670.
+ * 
+ * @param lan Pointer to the lan8670_t instance.
+ * @param data Buffer for the value.
+ * @return Status.
+ */
+int32_t LAN8670_Read_Model_Number(lan8670_t *lan, uint8_t *data);
+
 // clang-format on

--- a/general/src/lan8670.c
+++ b/general/src/lan8670.c
@@ -560,4 +560,34 @@ int32_t LAN8670_Get_Link_State(lan8670_t *lan, uint8_t *state)
     return LAN8670_STATUS_OK;
 }
 
+/* Returns the value of the PHY_ID1 register. This register contains the first 16 bits of the OUI (Organizationally Unique Identifier). Should be: 0b0000000000000111 in reset according to the datasheet. */
+int32_t LAN8670_Read_PHY_ID1(lan8670_t *lan, uint16_t *data) {
+    // Read all 16 bits of the PHY Identifier 1 register.
+    uint32_t value = 0;
+    int status = read_register_field(lan, REG_PHY_ID1, 0, 15, &value);
+    if(status != LAN8670_STATUS_OK) {
+        PRINTLN_ERROR("Failed to call read_register_field() (Status: %d).", status);
+        return status;
+    }
+
+    // Store the value
+    *data = (uint16_t)value;
+    return LAN8670_STATUS_OK;
+}
+
+/* Returns the PHY manufacturer's model number. Should be 0b00010110 for the LAN8670. */
+int32_t LAN8670_Read_Model_Number(lan8670_t *lan, uint8_t *data) {
+    // Read bits 9:4 of the PHY Identifier 2 Register.
+    uint32_t value = 0;
+    int status = read_register_field(lan, REG_PHY_ID2, 4, 9, &value);
+    if(status != LAN8670_STATUS_OK) {
+        PRINTLN_ERROR("Failed to call read_register_field() (Status: %d).", status);
+        return status;
+    }
+
+    // Store the value
+    *data = (uint8_t)value;
+    return LAN8670_STATUS_OK;
+}
+
 // clang-format on


### PR DESCRIPTION
Added `LAN8670_Read_PHY_ID1()` and `LAN8670_Read_Model_Number()` to the LAN8670 PHY driver. These functions should be helpful for debugging, since these register fields have known values.