### PR TITLE
Hardcoded PHY DevAddr

### DIFF
--- a/general/include/lan8670.h
+++ b/general/include/lan8670.h
@@ -226,4 +226,12 @@ int32_t LAN8670_Read_PHY_ID1(lan8670_t *lan, uint16_t *data);
  */
 int32_t LAN8670_Read_Model_Number(lan8670_t *lan, uint8_t *data);
 
+/**
+ * @brief Returns the PHY's device address according to the STRAP_CTRL0 register. This is a 5-bit value and should be consistent with how the device address is configured via the hardware pins.
+ * 
+ * @param lan Pointer to the lan8670_t instance.
+ * @param data Buffer for the value.
+ * @return Status.
+ */
+int32_t LAN8670_Read_PHY_DevAddr(lan8670_t *lan, uint8_t *data);
 // clang-format on

--- a/general/src/lan8670.c
+++ b/general/src/lan8670.c
@@ -595,4 +595,19 @@ int32_t LAN8670_Read_Model_Number(lan8670_t *lan, uint8_t *data) {
     return LAN8670_STATUS_OK;
 }
 
+/* Returns the 5-bit PHY device address. */
+int32_t LAN8670_Read_PHY_DevAddr(lan8670_t *lan, uint8_t *data) {
+    // Read bits 4:0 of the STRAP_CTRL0 register (containing the DevAddr configured by the hardware pins).
+    uint32_t buffer = 0;
+	int32_t status = read_register_field(lan, REG_STRAP_CTRL0, 0, 4, &buffer);
+    if(status != 0) {
+        PRINTLN_ERROR("Failed to call read_register_field() to read the STRAP_CTRL0 register (Status: %d).", status);
+        return LAN8670_STATUS_READ_ERROR;
+    }
+
+    // Store the value
+    *data = (uint8_t)buffer;
+    return LAN8670_STATUS_OK;
+}
+
 // clang-format on


### PR DESCRIPTION
Made it so the `LAN8670_Init()` function requires a hardcoded device address as a parameter. This is necessary for the PHY to function properly.

Also, added a `LAN8670_Read_PHY_DevAddr()`, which may be helpful when debugging and confirming the hardware DevAddr configuration.