### PR TITLE
FDCAN - Reject all messages by default

### DIFF
--- a/platforms/stm32h563/src/fdcan.c
+++ b/platforms/stm32h563/src/fdcan.c
@@ -37,6 +37,13 @@ HAL_StatusTypeDef can_init(can_t *can, FDCAN_HandleTypeDef *hcan)
 		return status;
 	}
 
+	/* Set up the global filter to reject all messages by default. You must explicitly add messages to your filters in the app layer to receive them. */
+	status = HAL_FDCAN_ConfigGlobalFilter(hcan, FDCAN_REJECT, FDCAN_REJECT, FDCAN_REJECT_REMOTE, FDCAN_REJECT_REMOTE);
+	if(status != HAL_OK) {
+		printf("[fdcan.c/can_init()] ERROR: Failed to run HAL_FDCAN_ConfigGlobalFilter() (Status: %d).\n", status);
+		return status;
+	}
+
 	return status;
 }
 


### PR DESCRIPTION
The FDCAN API now automatically sets up the global filter to reject all messages by default. This makes it so you have to manually set up your CAN filters in the application layer, so you can define exactly what messages you want to receive.